### PR TITLE
Feat/gpu support

### DIFF
--- a/chassisml-sdk/chassisml/__init__.py
+++ b/chassisml-sdk/chassisml/__init__.py
@@ -4,6 +4,6 @@
 """Chassis Python API Client."""
 
 name = 'chassisml'
-__version__ = '1.1.0'
+__version__ = '1.1.1'
 
 from .chassisml import ChassisClient,ChassisModel

--- a/chassisml-sdk/chassisml/_utils.py
+++ b/chassisml-sdk/chassisml/_utils.py
@@ -65,11 +65,13 @@ def fix_dependencies(model_directory):
         conda_w.write(conda)
         pip_w.write(pip)
 
-def write_modzy_yaml(model_name,model_version,output_path,batch_size=None):
+def write_modzy_yaml(model_name,model_version,output_path,batch_size=None,gpu=False):
     yaml_data = DEFAULT_MODZY_YAML_DATA
     yaml_data['name'] = model_name
     yaml_data['version'] = model_version
     if batch_size:
         yaml_data['features']['maxBatchSize'] = batch_size
+    if gpu:
+        yaml_data['resources']['gpu']['count'] = 1
     with open(output_path,'w',encoding = "utf-8") as f:
         f.write(yaml.dump(yaml_data))

--- a/chassisml-sdk/chassisml/chassisml.py
+++ b/chassisml-sdk/chassisml/chassisml.py
@@ -11,6 +11,7 @@ import tempfile
 import shutil
 import mlflow
 import base64
+import string
 import numpy as np
 from chassisml import __version__
 from ._utils import zipdir,fix_dependencies,write_modzy_yaml,NumpyEncoder
@@ -151,7 +152,7 @@ class ChassisModel(mlflow.pyfunc.PythonModel):
         print("Chassis model saved.")
 
     def publish(self,model_name,model_version,registry_user,registry_pass,
-                conda_env=None,fix_env=True,modzy_sample_input_path=None,
+                conda_env=None,fix_env=True,gpu=False,modzy_sample_input_path=None,
                 modzy_api_key=None):
 
         if (modzy_sample_input_path or modzy_api_key) and not \
@@ -170,13 +171,14 @@ class ChassisModel(mlflow.pyfunc.PythonModel):
             tmppath = tempfile.mkdtemp()
             zipdir(model_directory,tmppath,MODEL_ZIP_NAME)
             
-            image_name = "-".join(model_name.lower().split())
+            image_name = "-".join(model_name.translate(str.maketrans('', '', string.punctuation)).lower().split())
             image_data = {
                 'name': "{}/{}".format(registry_user,"{}:{}".format(image_name,model_version)),
                 'model_name': model_name,
                 'model_path': tmppath,
                 'registry_auth': base64.b64encode("{}:{}".format(registry_user,registry_pass).encode("utf-8")).decode("utf-8"),
-                'publish': True
+                'publish': True,
+                'gpu': gpu
             }
 
             if modzy_sample_input_path and modzy_api_key:
@@ -187,7 +189,7 @@ class ChassisModel(mlflow.pyfunc.PythonModel):
                     'deploy': True,
                     'api_key': modzy_api_key
                 }
-                write_modzy_yaml(model_name,model_version,modzy_metadata_path,batch_size=self.batch_size)
+                write_modzy_yaml(model_name,model_version,modzy_metadata_path,batch_size=self.batch_size,gpu=gpu)
             else:
                 modzy_data = {}
 

--- a/chassisml-sdk/examples/chassis-pytorch-batch-gpu.ipynb
+++ b/chassisml-sdk/examples/chassis-pytorch-batch-gpu.ipynb
@@ -61,7 +61,7 @@
     "            transforms.Normalize(mean=[0.485, 0.456, 0.406], std=[0.229, 0.224, 0.225])\n",
     "        ])        \n",
     "\n",
-    "# use GPU\n",
+    "# use GPU:\n",
     "device = 'cuda'\n",
     "model.to(device)\n",
     "\n",

--- a/chassisml-sdk/examples/chassis-pytorch-batch-gpu.ipynb
+++ b/chassisml-sdk/examples/chassis-pytorch-batch-gpu.ipynb
@@ -1,0 +1,278 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import chassisml\n",
+    "import pickle\n",
+    "import cv2\n",
+    "import torch\n",
+    "import getpass\n",
+    "import numpy as np\n",
+    "import torchvision.models as models\n",
+    "from torchvision import transforms"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Enter credentials\n",
+    "Dockerhub creds and Modzy API Key"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dockerhub_user = getpass.getpass('docker hub username')\n",
+    "dockerhub_pass = getpass.getpass('docker hub password')\n",
+    "modzy_api_key = getpass.getpass('modzy api key')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Prepare context dict\n",
+    "Initialize anything here that should persist across inference runs"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "model = models.resnet50(pretrained=True)\n",
+    "model.eval()\n",
+    "\n",
+    "labels = pickle.load(open('./modzy/imagenet_labels.pkl','rb'))\n",
+    "\n",
+    "transform = transforms.Compose([\n",
+    "            transforms.ToPILImage(),\n",
+    "            transforms.Resize(224),\n",
+    "            transforms.ToTensor(),\n",
+    "            transforms.Normalize(mean=[0.485, 0.456, 0.406], std=[0.229, 0.224, 0.225])\n",
+    "        ])        \n",
+    "\n",
+    "# use GPU\n",
+    "device = 'cuda'\n",
+    "model.to(device)\n",
+    "\n",
+    "# This will be passed to Chassis:\n",
+    "context = {\n",
+    "    \"model\": model,\n",
+    "    \"labels\": labels,\n",
+    "    \"transform\": transform,\n",
+    "    \"device\": device\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Write batch process function\n",
+    "\n",
+    "* Must take list[bytes] and context dict as input\n",
+    "* Preprocess all inputs, run inference in batch, postprocess batch model output, return list of formatted results"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def batch_process(inputs,context):\n",
+    "    \n",
+    "    # preprocess list of inputs\n",
+    "    images = []\n",
+    "    for input_bytes in inputs:\n",
+    "        decoded = cv2.imdecode(np.frombuffer(input_bytes, np.uint8), -1)\n",
+    "        resized = cv2.resize(decoded, (224, 224)).reshape((1,224,224,3))\n",
+    "        images.append(resized)\n",
+    "    images_arr = np.concatenate(images)\n",
+    "    batch_t = torch.stack(tuple(context['transform'](i) for i in images_arr), dim=0).to(context['device'])\n",
+    "\n",
+    "    # run batch inference and softmax\n",
+    "    output = context['model'](batch_t)\n",
+    "    probs = torch.nn.functional.softmax(output, dim=1)\n",
+    "    softmax_preds = probs.detach().cpu().numpy()\n",
+    "    \n",
+    "    # postprocess\n",
+    "    all_formatted_results = []\n",
+    "    for preds in softmax_preds: \n",
+    "        indices = np.argsort(preds)[::-1]\n",
+    "        classes = [context['labels'][idx] for idx in indices[:5]]\n",
+    "        scores = [float(preds[idx]) for idx in indices[:5]]\n",
+    "        preds = [{\"class\": \"{}\".format(label), \"score\": round(float(score),3)} for label, score in zip(classes, scores)]\n",
+    "        preds.sort(key = lambda x: x[\"score\"],reverse=True)\n",
+    "        results = {\"classPredictions\": preds}\n",
+    "        all_formatted_results.append(results)\n",
+    "    \n",
+    "    # output list of formatted results\n",
+    "    return all_formatted_results"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Initialize Chassis Client\n",
+    "We'll use this to interact with the Chassis service"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "chassis_client = chassisml.ChassisClient(\"http://localhost:5000\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Create and test Chassis model\n",
+    "* Requires `context` dict containing all variables which should be loaded once and persist across inferences\n",
+    "* Requires at least one of single input `process_fn` or batch input `batch_process_fn` defined above\n",
+    "    * If you provide `batch_process_fn`, you must also provide a `batch_size`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "b'{\"classPredictions\":[{\"class\":\"airliner\",\"score\":0.606},{\"class\":\"crane\",\"score\":0.11},{\"class\":\"wing\",\"score\":0.103},{\"class\":\"chain saw, chainsaw\",\"score\":0.07},{\"class\":\"aircraft carrier, carrier, flattop, attack aircraft carrier\",\"score\":0.048}]}'\n"
+     ]
+    }
+   ],
+   "source": [
+    "# create Chassis model\n",
+    "chassis_model = chassis_client.create_model(context=context,batch_process_fn=batch_process,batch_size=4)\n",
+    "\n",
+    "# test Chassis model (can pass filepath, bufferedreader, bytes, or text here):\n",
+    "sample_filepath = './modzy/airplane.jpg'\n",
+    "results = chassis_model.test(sample_filepath)\n",
+    "print(results)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[b'{\"classPredictions\":[{\"class\":\"airliner\",\"score\":0.606},{\"class\":\"crane\",\"score\":0.11},{\"class\":\"wing\",\"score\":0.103},{\"class\":\"chain saw, chainsaw\",\"score\":0.07},{\"class\":\"aircraft carrier, carrier, flattop, attack aircraft carrier\",\"score\":0.048}]}', b'{\"classPredictions\":[{\"class\":\"airliner\",\"score\":0.606},{\"class\":\"crane\",\"score\":0.11},{\"class\":\"wing\",\"score\":0.103},{\"class\":\"chain saw, chainsaw\",\"score\":0.07},{\"class\":\"aircraft carrier, carrier, flattop, attack aircraft carrier\",\"score\":0.048}]}', b'{\"classPredictions\":[{\"class\":\"airliner\",\"score\":0.606},{\"class\":\"crane\",\"score\":0.11},{\"class\":\"wing\",\"score\":0.103},{\"class\":\"chain saw, chainsaw\",\"score\":0.07},{\"class\":\"aircraft carrier, carrier, flattop, attack aircraft carrier\",\"score\":0.048}]}', b'{\"classPredictions\":[{\"class\":\"airliner\",\"score\":0.606},{\"class\":\"crane\",\"score\":0.11},{\"class\":\"wing\",\"score\":0.103},{\"class\":\"chain saw, chainsaw\",\"score\":0.07},{\"class\":\"aircraft carrier, carrier, flattop, attack aircraft carrier\",\"score\":0.048}]}']\n"
+     ]
+    }
+   ],
+   "source": [
+    "# test batch locally\n",
+    "results = chassis_model.test_batch(sample_filepath)\n",
+    "print(results)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Publish model to Modzy\n",
+    "Need to provide model name, model version, Dockerhub credentials, and required Modzy info"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Starting build job... Ok!\n"
+     ]
+    }
+   ],
+   "source": [
+    "response = chassis_model.publish(model_name=\"Torch Imagenet GPU\",model_version=\"0.0.1\",\n",
+    "                     registry_user=dockerhub_user,registry_pass=dockerhub_pass,\n",
+    "                     modzy_sample_input_path=sample_filepath,\n",
+    "                     modzy_api_key=modzy_api_key,gpu=True)\n",
+    "\n",
+    "job_id = response.get('job_id')\n",
+    "final_status = chassis_client.block_until_complete(job_id)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Run sample job\n",
+    "Submit inference job to our newly-deploy model running on Modzy"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from modzy import ApiClient\n",
+    "\n",
+    "client = ApiClient(base_url='https://integration.modzy.engineering/api', api_key=modzy_api_key)\n",
+    "\n",
+    "input_name = final_status['result']['inputs'][0]['name']\n",
+    "model_id = final_status['result'].get(\"model\").get(\"modelId\")\n",
+    "model_version = final_status['result'].get(\"version\")\n",
+    "\n",
+    "# submit 16 inputs\n",
+    "sources = {\"input_{}\".format(i): {input_name: sample_filepath} for i in range(16)}\n",
+    "inference_job = client.jobs.submit_file(model_id, model_version, sources)\n",
+    "inference_job_result = client.results.block_until_complete(inference_job, timeout=None)\n",
+    "print(inference_job_result[\"results\"])"
+   ]
+  }
+ ],
+ "metadata": {
+  "interpreter": {
+   "hash": "95ab8d3bdd708a5b71676285742277315a30b0df1ed91c8905076616709c59d5"
+  },
+  "kernelspec": {
+   "display_name": "chassis-demo",
+   "language": "python",
+   "name": "chassis-demo"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.5"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/chassisml-sdk/examples/chassis-pytorch-batch-gpu.ipynb
+++ b/chassisml-sdk/examples/chassis-pytorch-batch-gpu.ipynb
@@ -195,7 +195,7 @@
    "metadata": {},
    "source": [
     "## Publish model to Modzy\n",
-    "Need to provide model name, model version, Dockerhub credentials, and required Modzy info"
+    "Need to provide model name, model version, Dockerhub credentials, required Modzy info, AND specify gpu=True"
    ]
   },
   {

--- a/chassisml-sdk/examples/conda.yaml
+++ b/chassisml-sdk/examples/conda.yaml
@@ -6,7 +6,7 @@ dependencies:
   - python=3.8.5
   - pip:
     - modzy-sdk==0.6.0
-    - chassisml==1.1.0
+    - chassisml==1.1.1
     - cloudpickle==2.0.0
     - ipykernel==6.6.0
     - mlflow==1.22.0

--- a/chassisml-sdk/setup.py
+++ b/chassisml-sdk/setup.py
@@ -10,7 +10,7 @@ with open('README.md', 'r') as fh:
 
 setup(
     name='chassisml',
-    version='1.1.0',
+    version='1.1.1',
     author='Carlos Millán Soler',
     author_email='cmillan@sciling.com',
     description='Python API client for Chassis.',

--- a/modzy-uploader/app.py
+++ b/modzy-uploader/app.py
@@ -113,6 +113,9 @@ def _format_metadata(metadata):
                     'status': int(humanfriendly.parse_timespan(metadata['timeout']['status'])*1000)
                     }
 
+    gpu = metadata.get('resources',{}).get('gpu',{}).get('count')
+    if gpu:
+        body['requirement'] = {'requirementId': -6}               
     long_description = metadata.get('description').get('details')
     if long_description:
         body['longDescription'] = long_description

--- a/service/app.py
+++ b/service/app.py
@@ -24,6 +24,7 @@ WINDOWS = True if os.name == 'nt' else False
 
 HOME_DIR = str(Path.home())
 MODZY_UPLOADER_REPOSITORY = 'ghcr.io/modzy/chassis-modzy-uploader'
+
 if CHASSIS_DEV:
     MOUNT_PATH_DIR = "/"+ str(os.path.join(HOME_DIR,".chassis_data"))[3:].replace("\\", "/") if WINDOWS else os.path.join(HOME_DIR,".chassis_data")
 else:
@@ -41,6 +42,7 @@ K_KANIKO_EMPTY_DIR_PATH = os.getenv('K_KANIKO_EMPTY_DIR_PATH')
 K_SERVICE_ACCOUNT_NAME = "local-job-builder" if CHASSIS_DEV else os.getenv('K_SERVICE_ACCOUNT_NAME')
 K_JOB_NAME = os.getenv('K_JOB_NAME')
 
+GPU_BASE_IMAGE = 'nvidia/cuda:11.5.0-runtime-ubuntu20.04'
 
 ###########################################
 def create_dev_environment():
@@ -199,6 +201,7 @@ def create_job_object(
         modzy_data,
         publish,
         registry_auth,
+        gpu=False
 ):
     # This sets up all the objects needed to create a model image
 
@@ -256,7 +259,7 @@ def create_job_object(
     # This is the kaniko container used to build the final image.
 
     kaniko_args = [
-        f'--dockerfile={DATA_DIR}/flavours/{module_name}/Dockerfile',
+        f'--dockerfile={DATA_DIR}/flavours/{module_name}/Dockerfile{".gpu" if gpu else ""}',
         '' if publish else '--no-push',
         f'--tarPath={path_to_tar_file}',
         f'--destination={image_name}{"" if ":" in image_name else ":latest"}',
@@ -370,6 +373,7 @@ def run_kaniko(
         modzy_data,
         publish,
         registry_auth,
+        gpu=False
 ):
     # This method creates and launches a job object that uses Kaniko to
     # create the desired image.
@@ -393,6 +397,7 @@ def run_kaniko(
             modzy_data,
             publish,
             registry_auth,
+            gpu
         )
         create_job(batch_v1, job)
     except Exception as err:
@@ -492,6 +497,7 @@ def build_image():
     image_data = json.load(request.files.get('image_data'))
     model_name = image_data.get('model_name')
     image_name = image_data.get('name')
+    gpu = image_data.get('gpu')
     publish = image_data.get('publish', False)
     publish = True if publish else ''
     registry_auth = image_data.get('registry_auth')
@@ -540,6 +546,7 @@ def build_image():
         modzy_data,
         publish,
         registry_auth,
+        gpu
     )
 
     if error:

--- a/service/flavours/mlflow/Dockerfile.gpu
+++ b/service/flavours/mlflow/Dockerfile.gpu
@@ -28,11 +28,6 @@ ENV CONDA_ENV chassis-env
 
 # Create conda environment.
 RUN conda env create --name $CONDA_ENV --file ./conda.yaml
-# Install conda-pack.
-RUN conda install -c conda-forge conda-pack
-# Use conda-pack to create a standalone environment in /venv.
-RUN conda-pack -n $CONDA_ENV -o /tmp/env.tar && \
-  mkdir /venv && tar xf /tmp/env.tar -C /venv
 
 ARG MODEL_NAME
 
@@ -46,11 +41,10 @@ ENV INTERFACE ${INTERFACE}
 
 SHELL ["/bin/bash", "-c"]
 
-# Run conda-unpack to re-create symlinks and set everything up.
-RUN source /venv/bin/activate && conda-unpack
-
 COPY flavours/${MODEL_CLASS}/requirements.txt .
-RUN source /venv/bin/activate && pip install -r requirements.txt
+RUN /bin/bash -c "source activate chassis-env \
+    && pip install --no-cache-dir -r requirements.txt \
+    && conda deactivate"
 
 COPY flavours/${MODEL_CLASS}/app.py .
 COPY flavours/${MODEL_CLASS}/interfaces ./interfaces
@@ -58,6 +52,5 @@ COPY flavours/${MODEL_CLASS}/interfaces ./interfaces
 # Overwrite the default one.
 COPY ${MODZY_METADATA_PATH} ./interfaces/modzy/asset_bundle/0.1.0/model.yaml
 
-ENTRYPOINT ["/entrypoint.sh"]
+ENTRYPOINT ["conda", "run", "--no-capture-output", "-n", "chassis-env", "python", "app.py"]
 
-CMD ["python", "app.py"]

--- a/service/flavours/mlflow/Dockerfile.gpu
+++ b/service/flavours/mlflow/Dockerfile.gpu
@@ -1,0 +1,63 @@
+# The context is /workspace, which contains:
+# - flavours
+#   - mlflow
+
+FROM nvidia/cuda:11.0-runtime-ubuntu18.04 as build
+
+# Install miniconda
+RUN apt-get update && apt-get install -y curl
+RUN curl https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -o Miniconda3-latest-Linux-x86_64.sh
+RUN bash Miniconda3-latest-Linux-x86_64.sh -b -p /opt/miniconda3\
+    && rm -f Miniconda3-latest-Linux-x86_64.sh
+ENV PATH /opt/miniconda3/bin:$PATH
+
+# At the moment it's always model.
+ARG MODEL_DIR
+# Should be: mlflow.
+ARG MODEL_CLASS
+# Interface.
+ARG INTERFACE
+# This is the model.yaml file.
+ARG MODZY_METADATA_PATH
+
+WORKDIR /app
+
+COPY flavours/${MODEL_CLASS}/${MODEL_DIR}/conda.yaml ./conda.yaml
+
+ENV CONDA_ENV chassis-env
+
+# Create conda environment.
+RUN conda env create --name $CONDA_ENV --file ./conda.yaml
+# Install conda-pack.
+RUN conda install -c conda-forge conda-pack
+# Use conda-pack to create a standalone environment in /venv.
+RUN conda-pack -n $CONDA_ENV -o /tmp/env.tar && \
+  mkdir /venv && tar xf /tmp/env.tar -C /venv
+
+ARG MODEL_NAME
+
+WORKDIR /app
+
+COPY flavours/${MODEL_CLASS}/${MODEL_DIR} ./model/${MODEL_NAME}
+COPY flavours/${MODEL_CLASS}/entrypoint.sh /
+
+ENV MODEL_DIR ./model/${MODEL_NAME}
+ENV INTERFACE ${INTERFACE}
+
+SHELL ["/bin/bash", "-c"]
+
+# Run conda-unpack to re-create symlinks and set everything up.
+RUN source /venv/bin/activate && conda-unpack
+
+COPY flavours/${MODEL_CLASS}/requirements.txt .
+RUN source /venv/bin/activate && pip install -r requirements.txt
+
+COPY flavours/${MODEL_CLASS}/app.py .
+COPY flavours/${MODEL_CLASS}/interfaces ./interfaces
+
+# Overwrite the default one.
+COPY ${MODZY_METADATA_PATH} ./interfaces/modzy/asset_bundle/0.1.0/model.yaml
+
+ENTRYPOINT ["/entrypoint.sh"]
+
+CMD ["python", "app.py"]


### PR DESCRIPTION
User provides optional gpu flag in `chassis_model.publish()`, GPU requirement written to Modzy yaml and passed to Chassis service. Service selects a dockerfile based on this flag, and passes the flag along to the Modzy uploader. Modzy uploader lets Modzy know that it needs to use a GPU instance for this model once deployed. Added version of Torch example notebook with GPU support