### PR TITLE
Feat/diff modzy instances

### DIFF
--- a/chassisml-sdk/chassisml/__init__.py
+++ b/chassisml-sdk/chassisml/__init__.py
@@ -4,6 +4,6 @@
 """Chassis Python API Client."""
 
 name = 'chassisml'
-__version__ = '1.2.0'
+__version__ = '1.2.1'
 
 from .chassisml import ChassisClient,ChassisModel

--- a/chassisml-sdk/chassisml/_utils.py
+++ b/chassisml-sdk/chassisml/_utils.py
@@ -1,3 +1,4 @@
+from multiprocessing.sharedctypes import Value
 import os
 import yaml
 import json
@@ -5,6 +6,7 @@ import zipfile
 import numpy as np
 from chassisml import __version__
 from packaging import version
+import validators
 
 DEFAULT_MODZY_YAML_DATA = {'specification': '0.4',
         'type': 'grpc',
@@ -127,3 +129,12 @@ def write_modzy_yaml(model_name,model_version,output_path,batch_size=None,gpu=Fa
         yaml_data['resources']['gpu']['count'] = 1
     with open(output_path,'w',encoding = "utf-8") as f:
         f.write(yaml.dump(yaml_data))
+
+def check_modzy_url(modzy_url):
+    if not validators.url(modzy_url):
+        raise ValueError("Provided Modzy URL is not a valid URL")
+    if not modzy_url.startswith('https://'):
+        raise ValueError("Modzy URL must start with 'https://', example: 'https://my.modzy.com'")
+    if not modzy_url[-1].isalpha():
+        raise ValueError("Modzy URL must end with alpha char, example: 'https://my.modzy.com'")
+    return True

--- a/chassisml-sdk/chassisml/chassisml.py
+++ b/chassisml-sdk/chassisml/chassisml.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 # -*- coding utf-8 -*-
 
+from tabnanny import check
 import _io
 import os
 import time
@@ -15,7 +16,7 @@ import string
 import numpy as np
 import warnings
 from chassisml import __version__
-from ._utils import zipdir,fix_dependencies,write_modzy_yaml,NumpyEncoder,fix_dependencies_arm_gpu
+from ._utils import zipdir,fix_dependencies,write_modzy_yaml,NumpyEncoder,fix_dependencies_arm_gpu,check_modzy_url
 
 ###########################################
 MODEL_ZIP_NAME = 'model.zip'
@@ -231,7 +232,8 @@ class ChassisModel(mlflow.pyfunc.PythonModel):
 
     def publish(self,model_name,model_version,registry_user,registry_pass,
                 conda_env=None,fix_env=True,gpu=False,arm64=False,
-                modzy_sample_input_path=None,modzy_api_key=None):
+                modzy_sample_input_path=None,modzy_api_key=None,
+                modzy_url=None):
         '''
         Executes chassis job, which containerizes model, pushes container image to Docker registry, and optionally deploys model to Modzy
 
@@ -246,6 +248,7 @@ class ChassisModel(mlflow.pyfunc.PythonModel):
             arm64 (bool): If True, builds container image that runs on ARM64 architecture
             modzy_sample_input_path (str): Filepath to sample input data. Required to deploy model to Modzy
             modzy_api_key (str): Valid Modzy API Key
+            modzy_url (str): Valid Modzy instance URl, example: https://my.modzy.com
 
         Returns:
             Dict: Response to Chassis `/build` endpoint
@@ -270,9 +273,9 @@ class ChassisModel(mlflow.pyfunc.PythonModel):
 
         '''
 
-        if (modzy_sample_input_path or modzy_api_key) and not \
-            (modzy_sample_input_path and modzy_api_key):
-            raise ValueError('"modzy_sample_input_path", and "modzy_api_key" must both be provided to publish to Modzy.')
+        if (modzy_sample_input_path or modzy_api_key or modzy_url) and not \
+            (modzy_sample_input_path and modzy_api_key and modzy_url):
+            raise ValueError('"modzy_sample_input_path", "modzy_api_key" and "modzy_url" must all be provided to publish to Modzy.')
 
         try:
             model_directory = os.path.join(tempfile.mkdtemp(),CHASSIS_TMP_DIRNAME)
@@ -301,13 +304,14 @@ class ChassisModel(mlflow.pyfunc.PythonModel):
                 'arm64': arm64
             }
 
-            if modzy_sample_input_path and modzy_api_key:
+            if modzy_sample_input_path and modzy_api_key and check_modzy_url(modzy_url):
                 modzy_metadata_path = os.path.join(tmppath,MODZY_YAML_NAME)
                 modzy_data = {
                     'metadata_path': modzy_metadata_path,
                     'sample_input_path': modzy_sample_input_path,
                     'deploy': True,
-                    'api_key': modzy_api_key
+                    'api_key': modzy_api_key,
+                    'modzy_url': modzy_url
                 }
                 write_modzy_yaml(model_name,model_version,modzy_metadata_path,batch_size=self.batch_size,gpu=gpu)
             else:
@@ -342,12 +346,11 @@ class ChassisModel(mlflow.pyfunc.PythonModel):
             return res.json()
         
         except Exception as e:
-            print(e)
             if os.path.exists(tmppath):
                 shutil.rmtree(tmppath)
             if os.path.exists(model_directory):
                 shutil.rmtree(model_directory)
-            return False
+            raise(e)
 
 ###########################################
 

--- a/chassisml-sdk/examples/chassis-pytorch-batch-gpu.ipynb
+++ b/chassisml-sdk/examples/chassis-pytorch-batch-gpu.ipynb
@@ -212,10 +212,13 @@
     }
    ],
    "source": [
+    "modzy_url = \"https://my.modzy.com\"\n",
+    "\n",
     "response = chassis_model.publish(model_name=\"Torch Imagenet GPU\",model_version=\"0.0.1\",\n",
     "                     registry_user=dockerhub_user,registry_pass=dockerhub_pass,\n",
     "                     modzy_sample_input_path=sample_filepath,\n",
-    "                     modzy_api_key=modzy_api_key,gpu=True)\n",
+    "                     modzy_api_key=modzy_api_key,gpu=True,\n",
+    "                     modzy_url=modzy_url)\n",
     "\n",
     "job_id = response.get('job_id')\n",
     "final_status = chassis_client.block_until_complete(job_id)"
@@ -237,7 +240,7 @@
    "source": [
     "from modzy import ApiClient\n",
     "\n",
-    "client = ApiClient(base_url='https://integration.modzy.engineering/api', api_key=modzy_api_key)\n",
+    "client = ApiClient(base_url=f'{modzy_url}/api', api_key=modzy_api_key)\n",
     "\n",
     "input_name = final_status['result']['inputs'][0]['name']\n",
     "model_id = final_status['result'].get(\"model\").get(\"modelId\")\n",

--- a/chassisml-sdk/examples/chassis-pytorch-batch.ipynb
+++ b/chassisml-sdk/examples/chassis-pytorch-batch.ipynb
@@ -231,6 +231,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "modzy_url = \"https://my.modzy.com\"\n",
+    "\n",
     "response = chassis_model.publish(model_name=\"Torch Imagenet Batch\",model_version=\"0.0.1\",\n",
     "                     registry_user=dockerhub_user,registry_pass=dockerhub_pass,\n",
     "                     modzy_sample_input_path=sample_filepath,\n",
@@ -889,7 +891,7 @@
    "source": [
     "from modzy import ApiClient\n",
     "\n",
-    "client = ApiClient(base_url='https://integration.modzy.engineering/api', api_key=modzy_api_key)\n",
+    "client = ApiClient(base_url=f'{modzy_url}/api', api_key=modzy_api_key)\n",
     "\n",
     "input_name = final_status['result']['inputs'][0]['name']\n",
     "model_id = final_status['result'].get(\"model\").get(\"modelId\")\n",

--- a/chassisml-sdk/examples/chassis-pytorch.ipynb
+++ b/chassisml-sdk/examples/chassis-pytorch.ipynb
@@ -201,6 +201,8 @@
     }
    ],
    "source": [
+    "modzy_url = \"https://my.modzy.com\"\n",
+    "\n",
     "response = chassis_model.publish(model_name=\"Torch Imagenet\",model_version=\"0.0.1\",\n",
     "                     registry_user=dockerhub_user,registry_pass=dockerhub_pass,\n",
     "                     modzy_sample_input_path=sample_filepath,\n",
@@ -263,7 +265,7 @@
    "source": [
     "from modzy import ApiClient\n",
     "\n",
-    "client = ApiClient(base_url='https://integration.modzy.engineering/api', api_key=modzy_api_key)\n",
+    "client = ApiClient(base_url=f'{modzy_url}/api', api_key=modzy_api_key)\n",
     "\n",
     "input_name = final_status['result']['inputs'][0]['name']\n",
     "model_id = final_status['result'].get(\"model\").get(\"modelId\")\n",

--- a/chassisml-sdk/examples/chassis-sklearn.ipynb
+++ b/chassisml-sdk/examples/chassis-sklearn.ipynb
@@ -195,6 +195,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "modzy_url = \"https://my.modzy.com\"\n",
+    "\n",
     "response = chassis_model.publish(model_name=\"Sklearn Digits\",model_version=\"0.0.1\",\n",
     "                     registry_user=dockerhub_user,registry_pass=dockerhub_pass,\n",
     "                     modzy_sample_input_path=sample_filepath,\n",
@@ -220,7 +222,7 @@
    "source": [
     "from modzy import ApiClient\n",
     "\n",
-    "client = ApiClient(base_url='https://integration.modzy.engineering/api', api_key=modzy_api_key)\n",
+    "client = ApiClient(base_url=f'{modzy_url}/api', api_key=modzy_api_key)\n",
     "\n",
     "input_name = final_status['result']['inputs'][0]['name']\n",
     "model_id = final_status['result'].get(\"model\").get(\"modelId\")\n",

--- a/chassisml-sdk/setup.py
+++ b/chassisml-sdk/setup.py
@@ -10,7 +10,7 @@ with open('README.md', 'r') as fh:
 
 setup(
     name='chassisml',
-    version='1.2.0',
+    version='1.2.1',
     author='Carlos Millán Soler',
     author_email='cmillan@sciling.com',
     description='Python API client for Chassis.',
@@ -18,7 +18,7 @@ setup(
     long_description_content_type='text/markdown',
     packages=find_packages(include=['chassisml']),
     python_requires='>=3.6',
-    install_requires=['requests','mlflow','numpy','pyyaml'],
+    install_requires=['requests','mlflow','numpy','pyyaml','validators'],
     url='https://github.com/modzy/chassis/tree/main/chassisml-sdk',
     zip_safe=False,
 )

--- a/modzy-uploader/app.py
+++ b/modzy-uploader/app.py
@@ -20,11 +20,13 @@ parser.add_argument('--deploy', type=bool, required=False)
 parser.add_argument('--image_tag', type=str, required=False)
 parser.add_argument('--sample_input_path', type=str, required=False)
 parser.add_argument('--metadata_path', type=str, required=False)
+parser.add_argument('--modzy_url', type=str, required=False)
 args = parser.parse_args()
 
 JOB_NAME = os.getenv('JOB_NAME')
 ENVIRONMENT = os.getenv('ENVIRONMENT')
-MODZY_BASE_URL = 'https://integration.modzy.engineering'
+
+MODZY_BASE_URL = args.modzy_url
 
 r_session = requests.Session()
 

--- a/service/app.py
+++ b/service/app.py
@@ -23,8 +23,7 @@ CHASSIS_DEV = False
 WINDOWS = True if os.name == 'nt' else False
 
 HOME_DIR = str(Path.home())
-#MODZY_UPLOADER_REPOSITORY = 'ghcr.io/modzy/chassis-modzy-uploader'
-MODZY_UPLOADER_REPOSITORY = 'local-modzy-uploader:latest'
+MODZY_UPLOADER_REPOSITORY = 'ghcr.io/modzy/chassis-modzy-uploader'
 
 if CHASSIS_DEV:
     MOUNT_PATH_DIR = "/"+ str(os.path.join(HOME_DIR,".chassis_data"))[3:].replace("\\", "/") if WINDOWS else os.path.join(HOME_DIR,".chassis_data")
@@ -322,7 +321,6 @@ def create_job_object(
     modzy_uploader_container = client.V1Container(
         name='modzy-uploader',
         image=MODZY_UPLOADER_REPOSITORY,
-        image_pull_policy='Never',
         volume_mounts=[data_volume_mount],
         env=[
             client.V1EnvVar(name='JOB_NAME', value=job_name),

--- a/service/app.py
+++ b/service/app.py
@@ -23,7 +23,8 @@ CHASSIS_DEV = False
 WINDOWS = True if os.name == 'nt' else False
 
 HOME_DIR = str(Path.home())
-MODZY_UPLOADER_REPOSITORY = 'ghcr.io/modzy/chassis-modzy-uploader'
+#MODZY_UPLOADER_REPOSITORY = 'ghcr.io/modzy/chassis-modzy-uploader'
+MODZY_UPLOADER_REPOSITORY = 'local-modzy-uploader:latest'
 
 if CHASSIS_DEV:
     MOUNT_PATH_DIR = "/"+ str(os.path.join(HOME_DIR,".chassis_data"))[3:].replace("\\", "/") if WINDOWS else os.path.join(HOME_DIR,".chassis_data")
@@ -321,6 +322,7 @@ def create_job_object(
     modzy_uploader_container = client.V1Container(
         name='modzy-uploader',
         image=MODZY_UPLOADER_REPOSITORY,
+        image_pull_policy='Never',
         volume_mounts=[data_volume_mount],
         env=[
             client.V1EnvVar(name='JOB_NAME', value=job_name),
@@ -332,6 +334,7 @@ def create_job_object(
             f'--sample_input_path={modzy_data.get("modzy_sample_input_path")}',
             f'--metadata_path={DATA_DIR}/{modzy_data.get("modzy_metadata_path")}',
             f'--image_tag={image_name}{"" if ":" in image_name else ":latest"}',
+            f'--modzy_url={modzy_data.get("modzy_url")}'
         ]
     )
 
@@ -636,10 +639,8 @@ def build_image():
     if modzy_data:
         modzy_sample_input_path = extract_modzy_sample_input(modzy_sample_input_data, module_name, random_name)
         modzy_data['modzy_sample_input_path'] = modzy_sample_input_path
-
-    # TODO: this probably should only be done if modzy_data is true.
-    modzy_metadata_path = extract_modzy_metadata(modzy_metadata_data, module_name, random_name)
-    modzy_data['modzy_metadata_path'] = modzy_metadata_path
+        modzy_metadata_path = extract_modzy_metadata(modzy_metadata_data, module_name, random_name)
+        modzy_data['modzy_metadata_path'] = modzy_metadata_path
 
     # this path is the local location that kaniko will store the image it creates
     path_to_tar_file = f'{DATA_DIR}/kaniko_image-{random_name}.tar'


### PR DESCRIPTION
Updated SDK, Chassis Service, and Modzy Uploader:
Allows users to deploy models to different instances of Modzy.

PR Overview:
User must provide URL pointing to their instance of Modzy in their `chassis_model.publish()` call if Modzy deployment is desired. This will be passed all the way through to the Modzy Uploader.

PR Known Issues:
We don't check whether or not the URL provided actually points to an instance of Modzy until the Modzy Uploader step. We should discuss whether or not it makes sense to do this in the Chassis service prior to kicking off the build.