### PR TITLE
Feat/no context

### DIFF
--- a/chassisml-sdk/chassisml/__init__.py
+++ b/chassisml-sdk/chassisml/__init__.py
@@ -4,6 +4,6 @@
 """Chassis Python API Client."""
 
 name = 'chassisml'
-__version__ = '1.2.2'
+__version__ = '1.3.0'
 
 from .chassisml import ChassisClient,ChassisModel

--- a/chassisml-sdk/chassisml/chassisml.py
+++ b/chassisml-sdk/chassisml/chassisml.py
@@ -93,7 +93,7 @@ class ChassisModel(mlflow.pyfunc.PythonModel):
 
         Examples:
         ```python
-        chassis_model = chassis_client.create_model(context=context,process_fn=process)
+        chassis_model = chassis_client.create_model(process_fn=process)
         sample_filepath = './sample_data.json'
         results = chassis_model.test(sample_filepath)
         ```
@@ -124,7 +124,7 @@ class ChassisModel(mlflow.pyfunc.PythonModel):
 
         Examples:
         ```python
-        chassis_model = chassis_client.create_model(context=context,process_fn=process)
+        chassis_model = chassis_client.create_model(process_fn=process)
         sample_input = sample_filepath = './sample_data.json'
         results = chassis_model.test_batch(sample_filepath)
         ```        
@@ -166,7 +166,7 @@ class ChassisModel(mlflow.pyfunc.PythonModel):
 
         Examples:
         ```python
-        chassis_model = chassis_client.create_model(context=context,process_fn=process)
+        chassis_model = chassis_client.create_model(process_fn=process)
         sample_filepath = './sample_data.json'
         results = chassis_model.test_env(sample_filepath)
         ```        
@@ -216,7 +216,7 @@ class ChassisModel(mlflow.pyfunc.PythonModel):
         
         Examples:
         ```python
-        chassis_model = chassis_client.create_model(context=context,process_fn=process)
+        chassis_model = chassis_client.create_model(process_fn=process)
         chassis_model.save("local_model_directory")
         ```
         '''
@@ -256,7 +256,7 @@ class ChassisModel(mlflow.pyfunc.PythonModel):
         Examples:
         ```python
         # Create Chassisml model
-        chassis_model = chassis_client.create_model(context=context,process_fn=process)
+        chassis_model = chassis_client.create_model(process_fn=process)
 
         # Define Dockerhub credentials
         dockerhub_user = "user"
@@ -379,7 +379,7 @@ class ChassisClient:
         Examples:
         ```python
         # Create Chassisml model
-        chassis_model = chassis_client.create_model(context=context,process_fn=process)
+        chassis_model = chassis_client.create_model(process_fn=process)
 
         # Define Dockerhub credentials
         dockerhub_user = "user"
@@ -418,7 +418,7 @@ class ChassisClient:
         Examples:
         ```python
         # Create Chassisml model
-        chassis_model = chassis_client.create_model(context=context,process_fn=process)
+        chassis_model = chassis_client.create_model(process_fn=process)
 
         # Define Dockerhub credentials
         dockerhub_user = "user"
@@ -533,9 +533,8 @@ class ChassisClient:
         Builds chassis model locally
 
         Args:
-            context (dict): Dictionary that will contain the trained model object and any other inference-specific dependencies that will persist while model container is running. Should include all objects that only need to be loaded one time (e.g., loaded model, labels file(s), data transformation objects, etc.) that can be accessed during inference.
-            process_fn (function): Python function that must accept a single piece of input data in raw bytes form and `context` dictionary as input parameters. This method is responsible for handling all data preprocessing, executing inference, and returning the processed predictions. Defining additional functions is acceptable as long as they are called within the `process` method
-            batch_process_fn (function): Python function that must accept a batch of input data in raw bytes form and `context` dictionary as input parameters. This method is responsible for handling all data preprocessing, executing inference, and returning the processed predictions. Defining additional functions is acceptable as long as they are called within the `process` method
+            process_fn (function): Python function that must accept a single piece of input data in raw bytes form. This method is responsible for handling all data preprocessing, executing inference, and returning the processed predictions. Defining additional functions is acceptable as long as they are called within the `process` method
+            batch_process_fn (function): Python function that must accept a batch of input data in raw bytes form. This method is responsible for handling all data preprocessing, executing inference, and returning the processed predictions. Defining additional functions is acceptable as long as they are called within the `process` method
             batch_size (int): Maximum batch size if `batch_process_fn` is defined
 
         Returns:
@@ -569,7 +568,7 @@ class ChassisClient:
             json.dump(sample, out)        
 
         # Define Process function
-        def process(input_bytes,context):
+        def process(input_bytes):
             inputs = np.array(json.loads(input_bytes))
             inference_results = logistic.predict(inputs)
             structured_results = []

--- a/chassisml-sdk/examples/conda.yaml
+++ b/chassisml-sdk/examples/conda.yaml
@@ -6,7 +6,7 @@ dependencies:
   - python=3.8.5
   - pip:
     - modzy-sdk==0.6.0
-    - chassisml==1.1.2
+    - chassisml==1.3.0
     - cloudpickle==2.0.0
     - ipykernel==6.6.0
     - mlflow==1.22.0

--- a/chassisml-sdk/examples/fastai/fastai_tabular_training.ipynb
+++ b/chassisml-sdk/examples/fastai/fastai_tabular_training.ipynb
@@ -785,30 +785,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Prepare context dict\n",
-    "Initialize anything here that should persist across inference runs"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 25,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# This will be passed to Chassis:\n",
-    "context = {\n",
-    "    \"model\": learn,\n",
-    "    \"labels\": labels\n",
-    "}"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
     "## Write process function\n",
     "\n",
-    "* Must take bytes and context dict as input\n",
+    "* Must take bytes as input\n",
     "* Preprocess bytes, run inference, postprocess model output, return results"
    ]
   },
@@ -818,17 +797,17 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "def process(input_bytes,context):\n",
+    "def process(input_bytes):\n",
     "    inputs = pd.read_csv(StringIO(str(input_bytes, \"utf-8\")))\n",
-    "    dl = context[\"model\"].dls.test_dl(inputs)\n",
-    "    preds = context[\"model\"].get_preds(dl=dl)[0].numpy()\n",
+    "    dl = learn.dls.test_dl(inputs)\n",
+    "    preds = learn.get_preds(dl=dl)[0].numpy()\n",
     "    \n",
     "    inference_result = {\n",
     "        \"classPredictions\": [\n",
     "            {\n",
     "                \"row\": i+1,\n",
     "                \"predictions\": [\n",
-    "                    {\"class\": context[\"labels\"][j], \"score\": round(pred[j], 4)} for j in range(2)\n",
+    "                    {\"class\": labels[j], \"score\": round(pred[j], 4)} for j in range(2)\n",
     "                ]\n",
     "            } for i, pred in enumerate(preds)\n",
     "        ]\n",
@@ -867,7 +846,6 @@
    "metadata": {},
    "source": [
     "## Create and test Chassis model\n",
-    "* Requires `context` dict containing all variables which should be loaded once and persist across inferences\n",
     "* Requires `process_fn` defined above"
    ]
   },
@@ -922,7 +900,7 @@
    ],
    "source": [
     "# create Chassis model\n",
-    "chassis_model = chassis_client.create_model(context=context,process_fn=process)\n",
+    "chassis_model = chassis_client.create_model(process_fn=process)\n",
     "\n",
     "# test Chassis model locally (can pass filepath, bufferedreader, bytes, or text here):\n",
     "sample_filepath = './data/sample_adult_data.csv'\n",

--- a/chassisml-sdk/examples/lightgbm/lightgbm_classification.ipynb
+++ b/chassisml-sdk/examples/lightgbm/lightgbm_classification.ipynb
@@ -168,30 +168,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Prepare context dict\n",
-    "Initialize anything here that should persist across inference runs"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 31,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# This will be passed to Chassis:\n",
-    "context = {\n",
-    "    \"model\": clf,\n",
-    "    \"classes\": [\"No Cancer\", \"Cancer\"]\n",
-    "}"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
     "## Write process function\n",
     "\n",
-    "* Must take bytes and context dict as input\n",
+    "* Must take bytes as input\n",
     "* Preprocess bytes, run inference, postprocess model output, return results"
    ]
   },
@@ -201,13 +180,14 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "def process(input_bytes,context):\n",
+    "classes = [\"No Cancer\", \"Cancer\"]\n",
+    "def process(input_bytes):\n",
     "    inputs = pd.read_csv(StringIO(str(input_bytes, \"utf-8\")))\n",
-    "    preds = context[\"model\"].predict_proba(inputs)\n",
+    "    preds = clf.predict_proba(inputs)\n",
     "    \n",
     "    inference_result = {\n",
     "        \"classPredictions\": [\n",
-    "            {\"row\": i+1, \"class\": context[\"classes\"][np.argmax(pred)], \"score\": np.max(pred)} for i, pred in enumerate(preds)\n",
+    "            {\"row\": i+1, \"class\": classes[np.argmax(pred)], \"score\": np.max(pred)} for i, pred in enumerate(preds)\n",
     "        ]\n",
     "    }\n",
     "    \n",
@@ -244,7 +224,6 @@
    "metadata": {},
    "source": [
     "## Create and test Chassis model\n",
-    "* Requires `context` dict containing all variables which should be loaded once and persist across inferences\n",
     "* Requires `process_fn` defined above"
    ]
   },
@@ -265,7 +244,7 @@
    ],
    "source": [
     "# create Chassis model\n",
-    "chassis_model = chassis_client.create_model(context=context,process_fn=process)\n",
+    "chassis_model = chassis_client.create_model(process_fn=process)\n",
     "\n",
     "# test Chassis model locally (can pass filepath, bufferedreader, bytes, or text here):\n",
     "sample_filepath = 'data/sample_cancer_data.csv'\n",

--- a/chassisml-sdk/examples/lightgbm/lightgbm_regression.ipynb
+++ b/chassisml-sdk/examples/lightgbm/lightgbm_regression.ipynb
@@ -1056,29 +1056,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Prepare context dict\n",
-    "Initialize anything here that should persist across inference runs"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 70,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# This will be passed to Chassis:\n",
-    "context = {\n",
-    "    \"model\": gbm\n",
-    "}"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
     "## Write process function\n",
     "\n",
-    "* Must take bytes and context dict as input\n",
+    "* Must take bytes as input\n",
     "* Preprocess bytes, run inference, postprocess model output, return results"
    ]
   },
@@ -1088,9 +1068,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "def process(input_bytes,context):\n",
+    "def process(input_bytes):\n",
     "    inputs = pd.read_csv(StringIO(str(input_bytes, \"utf-8\")))\n",
-    "    preds = np.expm1(context[\"model\"].predict(inputs, num_iteration=context[\"model\"].best_iteration_))\n",
+    "    preds = np.expm1(gbm.predict(inputs, num_iteration=gbm.best_iteration_))\n",
     "    \n",
     "    inference_result = {\n",
     "        \"costPredictions\": [\n",
@@ -1131,7 +1111,6 @@
    "metadata": {},
    "source": [
     "## Create and test Chassis model\n",
-    "* Requires `context` dict containing all variables which should be loaded once and persist across inferences\n",
     "* Requires `process_fn` defined above"
    ]
   },
@@ -1152,7 +1131,7 @@
    ],
    "source": [
     "# create Chassis model\n",
-    "chassis_model = chassis_client.create_model(context=context,process_fn=process)\n",
+    "chassis_model = chassis_client.create_model(process_fn=process)\n",
     "\n",
     "# test Chassis model locally (can pass filepath, bufferedreader, bytes, or text here):\n",
     "sample_filepath = './data/house_costs_sample.csv'\n",

--- a/chassisml-sdk/examples/mxnet/mxnet_mobilenet_image_classification.ipynb
+++ b/chassisml-sdk/examples/mxnet/mxnet_mobilenet_image_classification.ipynb
@@ -183,31 +183,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Prepare context dict\n",
-    "Initialize anything here that should persist across inference runs"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 91,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# This will be passed to Chassis:\n",
-    "context = {\n",
-    "    \"model\": mobileNet,\n",
-    "    \"labels\": imagenet_labels,\n",
-    "    \"predict_fn\": predict\n",
-    "}"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
     "## Write process function\n",
     "\n",
-    "* Must take bytes and context dict as input\n",
+    "* Must take bytes as input\n",
     "* Preprocess bytes, run inference, postprocess model output, return results"
    ]
   },
@@ -217,12 +195,12 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "def process(input_bytes,context):\n",
+    "def process(input_bytes):\n",
     "    # read image bytes\n",
     "    img = mxnet_img.imdecode(input_bytes)\n",
     "    \n",
     "    # run inference\n",
-    "    probs, labels = context[\"predict_fn\"](context[\"model\"], img, context[\"labels\"], 3)\n",
+    "    probs, labels = predict(mobileNet, img, labels, 3)\n",
     "    \n",
     "    # structure results\n",
     "    inference_result = {\n",
@@ -263,7 +241,6 @@
    "metadata": {},
    "source": [
     "## Create and test Chassis model\n",
-    "* Requires `context` dict containing all variables which should be loaded once and persist across inferences\n",
     "* Requires `process_fn` defined above"
    ]
   },
@@ -284,7 +261,7 @@
    ],
    "source": [
     "# create Chassis model\n",
-    "chassis_model = chassis_client.create_model(context=context,process_fn=process)\n",
+    "chassis_model = chassis_client.create_model(process_fn=process)\n",
     "\n",
     "# test Chassis model locally (can pass filepath, bufferedreader, bytes, or text here):\n",
     "sample_filepath = './data/dog.jpg'\n",

--- a/chassisml-sdk/examples/onnx/onnx_mobilenet_image_classification.ipynb
+++ b/chassisml-sdk/examples/onnx/onnx_mobilenet_image_classification.ipynb
@@ -147,30 +147,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Prepare context dict\n",
-    "Initialize anything here that should persist across inference runs"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 17,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# This will be passed to Chassis:\n",
-    "context = {\n",
-    "    \"model\": model,\n",
-    "    \"labels\": labels\n",
-    "}"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
     "## Write process function\n",
     "\n",
-    "* Must take bytes and context dict as input\n",
+    "* Must take bytes as input\n",
     "* Preprocess bytes, run inference, postprocess model output, return results"
    ]
   },
@@ -180,11 +159,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "def process(input_bytes,context):\n",
+    "def process(input_bytes):\n",
     "    # save model to filepath for inference\n",
     "    tmp_dir = tempfile.mkdtemp()\n",
     "    import onnx\n",
-    "    onnx.save(context[\"model\"], \"{}/model.onnx\".format(tmp_dir))\n",
+    "    onnx.save(model, \"{}/model.onnx\".format(tmp_dir))\n",
     "    \n",
     "    # preprocess data\n",
     "    decoded = cv2.cvtColor(cv2.imdecode(np.frombuffer(input_bytes, np.uint8), -1), cv2.COLOR_BGR2RGB)\n",
@@ -196,7 +175,7 @@
     "    results = session.run(None, {\"input\": img})\n",
     "    \n",
     "    # postprocess\n",
-    "    inference_result = context[\"labels\"][results[0].argmax()]\n",
+    "    inference_result = labels[results[0].argmax()]\n",
     "    \n",
     "    # format results\n",
     "    structured_result = {\n",
@@ -232,7 +211,6 @@
    "metadata": {},
    "source": [
     "## Create and test Chassis model\n",
-    "* Requires `context` dict containing all variables which should be loaded once and persist across inferences\n",
     "* Requires `process_fn` defined above"
    ]
   },
@@ -245,7 +223,7 @@
    "outputs": [],
    "source": [
     "# create Chassis model\n",
-    "chassis_model = chassis_client.create_model(context=context,process_fn=process)\n",
+    "chassis_model = chassis_client.create_model(process_fn=process)\n",
     "\n",
     "# test Chassis model locally (can pass filepath, bufferedreader, bytes, or text here):\n",
     "sample_filepath = './data/dog.jpg'\n",

--- a/chassisml-sdk/examples/onnx/onnx_transformer_text_generation.ipynb
+++ b/chassisml-sdk/examples/onnx/onnx_transformer_text_generation.ipynb
@@ -161,29 +161,12 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": 13,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# This will be passed to Chassis:\n",
-    "context = {\n",
-    "    \"model\": head_model,\n",
-    "    \"tokenizer\": tokenizer,\n",
-    "    \"utilities\": {\n",
-    "        \"flatten\": flatten,\n",
-    "        \"to_numpy\": to_numpy\n",
-    "    }\n",
-    "}"
-   ]
-  },
-  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
     "## Write process function\n",
     "\n",
-    "* Must take bytes and context dict as input\n",
+    "* Must take bytes as input\n",
     "* Preprocess bytes, run inference, postprocess model output, return results"
    ]
   },
@@ -193,7 +176,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "def process(input_bytes,context):\n",
+    "def process(input_bytes):\n",
     "    # initialize fixed variables for post processing\n",
     "    batch_size = 1\n",
     "    length = 10\n",
@@ -201,11 +184,11 @@
     "    # save model to filepath for inference\n",
     "    tmp_dir = tempfile.mkdtemp()\n",
     "    import onnx\n",
-    "    onnx.save(context[\"model\"], \"{}/head_model.onnx\".format(tmp_dir))\n",
+    "    onnx.save(head_model, \"{}/head_model.onnx\".format(tmp_dir))\n",
     "    \n",
     "    # preprocess text\n",
     "    text_input = input_bytes.decode()\n",
-    "    tokens = np.array(context[\"tokenizer\"].encode(text_input, add_special_tokens=True))\n",
+    "    tokens = np.array(tokenizer.encode(text_input, add_special_tokens=True))\n",
     "    tensors = torch.tensor([[tokens]])\n",
     "\n",
     "    # run inference \n",
@@ -215,7 +198,7 @@
     "        if len(prev.shape) == 2:\n",
     "            prev = prev.unsqueeze(0)     \n",
     "        session = ort.InferenceSession(\"{}/head_model.onnx\".format(tmp_dir))\n",
-    "        ort_inputs = dict((session.get_inputs()[i].name, context[\"utilities\"][\"to_numpy\"](input)) for i, input in enumerate(context[\"utilities\"][\"flatten\"](prev)))\n",
+    "        ort_inputs = dict((session.get_inputs()[i].name, to_numpy(input)) for i, input in enumerate(flatten(prev)))\n",
     "        outputs = session.run(None, ort_inputs)\n",
     "        logits = torch.tensor(outputs[0]).squeeze(0)\n",
     "        logits = logits[:, -1, :]\n",
@@ -268,7 +251,6 @@
    "metadata": {},
    "source": [
     "## Create and test Chassis model\n",
-    "* Requires `context` dict containing all variables which should be loaded once and persist across inferences\n",
     "* Requires `process_fn` defined above"
    ]
   },
@@ -289,7 +271,7 @@
    ],
    "source": [
     "# create Chassis model\n",
-    "chassis_model = chassis_client.create_model(context=context,process_fn=process)\n",
+    "chassis_model = chassis_client.create_model(process_fn=process)\n",
     "\n",
     "# test Chassis model locally (can pass filepath, bufferedreader, bytes, or text here):\n",
     "sample_filepath = 'data/sample_text.txt'\n",

--- a/chassisml-sdk/examples/pmml/pmml_iris_forest_classification.ipynb
+++ b/chassisml-sdk/examples/pmml/pmml_iris_forest_classification.ipynb
@@ -119,7 +119,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Prepare context dict\n",
+    "## Prepare pre and post-processing methods\n",
     "Initialize anything here that should persist across inference runs"
    ]
   },
@@ -141,7 +141,7 @@
     "            {\n",
     "                \"row\": i+1,\n",
     "                \"classPredictions\": [\n",
-    "                    {\"class\": context['labels'][idx], \"score\": results[idx]}\n",
+    "                    {\"class\": labels[idx], \"score\": results[idx]}\n",
     "                    for idx in np.argsort(results)[::-1]\n",
     "                ]  \n",
     "            } for i, results in enumerate(raw_predictions)\n",
@@ -163,25 +163,12 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": 8,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# This will be passed to Chassis:\n",
-    "context = {\n",
-    "    \"model\": clf,\n",
-    "    \"labels\": labels\n",
-    "}"
-   ]
-  },
-  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
     "## Write process function\n",
     "\n",
-    "* Must take bytes and context dict as input\n",
+    "* Must take bytes as input\n",
     "* Preprocess bytes, run inference, postprocess model output, return results"
    ]
   },
@@ -191,11 +178,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "def process(input_bytes,context):\n",
+    "def process(input_bytes):\n",
     "    # load data\n",
     "    inputs = preprocess_inputs(input_bytes)\n",
     "    # make predictions\n",
-    "    output = context[\"model\"].predict_proba(inputs)\n",
+    "    output = clf.predict_proba(inputs)\n",
     "    # process output\n",
     "    structured_output = postprocess_outputs(output)\n",
     "    return structured_output"
@@ -223,7 +210,6 @@
    "metadata": {},
    "source": [
     "## Create and test Chassis model\n",
-    "* Requires `context` dict containing all variables which should be loaded once and persist across inferences\n",
     "* Requires `process_fn` defined above"
    ]
   },
@@ -244,7 +230,7 @@
    ],
    "source": [
     "# create Chassis model\n",
-    "chassis_model = chassis_client.create_model(context=context,process_fn=process)\n",
+    "chassis_model = chassis_client.create_model(process_fn=process)\n",
     "\n",
     "# test Chassis model locally (can pass filepath, bufferedreader, bytes, or text here):\n",
     "sample_filepath = './data/sample_iris.csv'\n",

--- a/chassisml-sdk/examples/pmml/pmml_linear_regression.ipynb
+++ b/chassisml-sdk/examples/pmml/pmml_linear_regression.ipynb
@@ -109,29 +109,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Prepare context dict\n",
-    "Initialize anything here that should persist across inference runs"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 15,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# This will be passed to Chassis:\n",
-    "context = {\n",
-    "    \"model\": clf,\n",
-    "}"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
     "## Write process function\n",
     "\n",
-    "* Must take bytes and context dict as input\n",
+    "* Must take bytes as input\n",
     "* Preprocess bytes, run inference, postprocess model output, return results"
    ]
   },
@@ -141,12 +121,12 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "def process(input_bytes,context):\n",
+    "def process(input_bytes):\n",
     "    # load data\n",
     "    inputs = pd.read_csv(StringIO(str(input_bytes, \"utf-8\")))\n",
     "    \n",
     "    # predictions\n",
-    "    output = context[\"model\"].predict(inputs)\n",
+    "    output = clf.predict(inputs)\n",
     "    \n",
     "    # process output\n",
     "    inference_result = {\n",
@@ -189,7 +169,6 @@
    "metadata": {},
    "source": [
     "## Create and test Chassis model\n",
-    "* Requires `context` dict containing all variables which should be loaded once and persist across inferences\n",
     "* Requires `process_fn` defined above"
    ]
   },
@@ -218,7 +197,7 @@
    ],
    "source": [
     "# create Chassis model\n",
-    "chassis_model = chassis_client.create_model(context=context,process_fn=process)\n",
+    "chassis_model = chassis_client.create_model(process_fn=process)\n",
     "\n",
     "# test Chassis model locally (can pass filepath, bufferedreader, bytes, or text here):\n",
     "sample_filepath = './data/sample_regression.csv'\n",

--- a/chassisml-sdk/examples/pytorch/pytorch_deeplab_resnet50_semantic_segmentation.ipynb
+++ b/chassisml-sdk/examples/pytorch/pytorch_deeplab_resnet50_semantic_segmentation.ipynb
@@ -65,7 +65,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Prepare context dict\n",
+    "## Prepare model and data transform\n",
     "Initialize anything here that should persist across inference runs"
    ]
   },
@@ -92,15 +92,7 @@
     "]\n",
     "sem_class_to_idx = {cls: idx for (idx, cls) in enumerate(sem_classes)}\n",
     "\n",
-    "device = 'cpu'\n",
-    "\n",
-    "# This will be passed to Chassis:\n",
-    "context = {\n",
-    "    \"model\": model,\n",
-    "    \"transform\": transform,\n",
-    "    \"device\": device,\n",
-    "    \"labels\": sem_class_to_idx\n",
-    "}"
+    "device = 'cpu'"
    ]
   },
   {
@@ -109,7 +101,7 @@
    "source": [
     "## Write process function\n",
     "\n",
-    "* Must take bytes and context dict as input\n",
+    "* Must take bytes as input\n",
     "* Preprocess bytes, run inference, postprocess model output, return results"
    ]
   },
@@ -119,15 +111,15 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "def process(input_bytes,context):\n",
+    "def process(input_bytes):\n",
     "    \n",
     "    # preprocess\n",
     "    decoded = cv2.imdecode(np.frombuffer(input_bytes, np.uint8), -1)\n",
-    "    img_t = context['transform'](decoded)\n",
-    "    batch_t = torch.unsqueeze(img_t, 0).to(context[\"device\"])\n",
+    "    img_t = transform(decoded)\n",
+    "    batch_t = torch.unsqueeze(img_t, 0).to(device)\n",
     "    \n",
     "    # run inference\n",
-    "    predictions = context['model'](batch_t)[\"out\"]\n",
+    "    predictions = model(batch_t)[\"out\"]\n",
     "    \n",
     "    # postprocess\n",
     "    normalized_masks = torch.nn.functional.softmax(predictions, dim=1)\n",
@@ -173,7 +165,6 @@
    "metadata": {},
    "source": [
     "## Create and test Chassis model\n",
-    "* Requires `context` dict containing all variables which should be loaded once and persist across inferences\n",
     "* Requires `process_fn` defined above"
    ]
   },
@@ -184,7 +175,7 @@
    "outputs": [],
    "source": [
     "# create Chassis model\n",
-    "chassis_model = chassis_client.create_model(context=context,process_fn=process)\n",
+    "chassis_model = chassis_client.create_model(process_fn=process)\n",
     "\n",
     "# test Chassis model (can pass filepath, bufferedreader, bytes, or text here):\n",
     "sample_filepath = './data/dog.jpg'\n",

--- a/chassisml-sdk/examples/pytorch/pytorch_fastrcnn_object_detection.ipynb
+++ b/chassisml-sdk/examples/pytorch/pytorch_fastrcnn_object_detection.ipynb
@@ -65,7 +65,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Prepare context dict\n",
+    "## Prepare model, labels, and data transform\n",
     "Initialize anything here that should persist across inference runs"
    ]
   },
@@ -102,7 +102,7 @@
     "\n",
     "def preprocess(input_bytes):\n",
     "    decoded = cv2.imdecode(np.frombuffer(input_bytes, np.uint8), -1)\n",
-    "    img_t = context['transform'](decoded)\n",
+    "    img_t = transform(decoded)\n",
     "    batch_t = torch.unsqueeze(img_t, 0).to(device)\n",
     "    return batch_t\n",
     "\n",
@@ -114,7 +114,7 @@
     "                \"xMax\": predictions[\"boxes\"][i].detach().cpu().numpy().tolist()[2],\n",
     "                \"yMin\": predictions[\"boxes\"][i].detach().cpu().numpy().tolist()[1],\n",
     "                \"yMax\": predictions[\"boxes\"][i].detach().cpu().numpy().tolist()[3],\n",
-    "                \"class\": context[\"labels\"][predictions[\"labels\"][i].detach().cpu().item()],\n",
+    "                \"class\": labels[predictions[\"labels\"][i].detach().cpu().item()],\n",
     "                \"classProbability\": predictions[\"scores\"][i].detach().cpu().item(),\n",
     "            } for i in range(num_detections)\n",
     "        ]\n",
@@ -131,29 +131,12 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": 4,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# This will be passed to Chassis:\n",
-    "context = {\n",
-    "    \"model\": model,\n",
-    "    \"labels\": COCO_INSTANCE_CATEGORY_NAMES,\n",
-    "    \"transform\": transform,\n",
-    "    \"device\": device,\n",
-    "    \"preprocess\": preprocess,\n",
-    "    \"postprocess\": postprocess\n",
-    "}"
-   ]
-  },
-  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
     "## Write process function\n",
     "\n",
-    "* Must take bytes and context dict as input\n",
+    "* Must take bytes as input\n",
     "* Preprocess bytes, run inference, postprocess model output, return results"
    ]
   },
@@ -163,17 +146,17 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "def process(input_bytes,context):\n",
+    "def process(input_bytes):\n",
     "    \n",
     "    # preprocess\n",
-    "    batch_t = context[\"preprocess\"](input_bytes)\n",
+    "    batch_t = preprocess(input_bytes)\n",
     "    \n",
     "    # run inference\n",
-    "    predictions = context['model'](batch_t)[0]\n",
+    "    predictions = model(batch_t)[0]\n",
     "    num_detections = len(predictions[\"boxes\"])\n",
     "    \n",
     "    # postprocess\n",
-    "    structured_output = context[\"postprocess\"](num_detections, predictions)\n",
+    "    structured_output = postprocess(num_detections, predictions)\n",
     "    \n",
     "    return structured_output"
    ]
@@ -200,36 +183,19 @@
    "metadata": {},
    "source": [
     "## Create and test Chassis model\n",
-    "* Requires `context` dict containing all variables which should be loaded once and persist across inferences\n",
     "* Requires `process_fn` defined above"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "metadata": {
     "scrolled": true
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "b'{\"data\":{\"result\":{\"detections\":[{\"xMin\":112.44477844238281,\"xMax\":594.023681640625,\"yMin\":10.943532943725586,\"yMax\":201.69760131835938,\"class\":\"airplane\",\"classProbability\":0.9996569156646729}]},\"explanation\":null,\"drift\":null}}'\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "C:\\tools\\Anaconda3\\envs\\chassis-demo\\lib\\site-packages\\torch\\functional.py:445: UserWarning: torch.meshgrid: in an upcoming release, it will be required to pass the indexing argument. (Triggered internally at  ..\\aten\\src\\ATen\\native\\TensorShape.cpp:2157.)\n",
-      "  return _VF.meshgrid(tensors, **kwargs)  # type: ignore[attr-defined]\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# create Chassis model\n",
-    "chassis_model = chassis_client.create_model(context=context,process_fn=process)\n",
+    "chassis_model = chassis_client.create_model(process_fn=process)\n",
     "\n",
     "# test Chassis model (can pass filepath, bufferedreader, bytes, or text here):\n",
     "sample_filepath = './data/airplane.jpg'\n",

--- a/chassisml-sdk/examples/pytorch/pytorch_resnet50_image_classification.ipynb
+++ b/chassisml-sdk/examples/pytorch/pytorch_resnet50_image_classification.ipynb
@@ -65,7 +65,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Prepare context dict\n",
+    "## Prepare model, labels, and data transform object\n",
     "Initialize anything here that should persist across inference runs"
    ]
   },
@@ -87,15 +87,7 @@
     "            transforms.Normalize(mean=[0.485, 0.456, 0.406], std=[0.229, 0.224, 0.225])\n",
     "        ])        \n",
     "\n",
-    "device = 'cpu'\n",
-    "\n",
-    "# This will be passed to Chassis:\n",
-    "context = {\n",
-    "    \"model\": model,\n",
-    "    \"labels\": labels,\n",
-    "    \"transform\": transform,\n",
-    "    \"device\": device\n",
-    "}"
+    "device = 'cpu'"
    ]
   },
   {
@@ -104,7 +96,7 @@
    "source": [
     "## Write process function\n",
     "\n",
-    "* Must take bytes and context dict as input\n",
+    "* Must take bytes as input\n",
     "* Preprocess bytes, run inference, postprocess model output, return results"
    ]
   },
@@ -114,15 +106,15 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "def process(input_bytes,context):\n",
+    "def process(input_bytes):\n",
     "    \n",
     "    # preprocess\n",
     "    decoded = cv2.imdecode(np.frombuffer(input_bytes, np.uint8), -1)\n",
-    "    img_t = context['transform'](decoded)\n",
+    "    img_t = transform(decoded)\n",
     "    batch_t = torch.unsqueeze(img_t, 0).to(device)\n",
     "    \n",
     "    # run inference\n",
-    "    predictions = context['model'](batch_t)\n",
+    "    predictions = model(batch_t)\n",
     "    \n",
     "    # postprocess\n",
     "    percentage = torch.nn.functional.softmax(predictions, dim=1)[0]\n",
@@ -130,7 +122,7 @@
     "    _, indices = torch.sort(predictions, descending=True)\n",
     "    inference_result = {\n",
     "        \"classPredictions\": [\n",
-    "            {\"class\": context['labels'][idx.item()], \"score\": percentage[idx].item()}\n",
+    "            {\"class\": labels[idx.item()], \"score\": percentage[idx].item()}\n",
     "        for idx in indices[0][:5] ]\n",
     "    }\n",
     "\n",
@@ -167,7 +159,6 @@
    "metadata": {},
    "source": [
     "## Create and test Chassis model\n",
-    "* Requires `context` dict containing all variables which should be loaded once and persist across inferences\n",
     "* Requires `process_fn` defined above"
    ]
   },
@@ -186,7 +177,7 @@
    ],
    "source": [
     "# create Chassis model\n",
-    "chassis_model = chassis_client.create_model(context=context,process_fn=process)\n",
+    "chassis_model = chassis_client.create_model(process_fn=process)\n",
     "\n",
     "# test Chassis model (can pass filepath, bufferedreader, bytes, or text here):\n",
     "sample_filepath = './data/airplane.jpg'\n",

--- a/chassisml-sdk/examples/pytorch/pytorch_resnet50_image_classification_batch_gpu.ipynb
+++ b/chassisml-sdk/examples/pytorch/pytorch_resnet50_image_classification_batch_gpu.ipynb
@@ -65,7 +65,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Prepare context dict\n",
+    "## Prepare model, data transform object, and labels\n",
     "Initialize anything here that should persist across inference runs"
    ]
   },
@@ -89,15 +89,7 @@
     "\n",
     "# use GPU:\n",
     "device = 'cuda'\n",
-    "model.to(device)\n",
-    "\n",
-    "# This will be passed to Chassis:\n",
-    "context = {\n",
-    "    \"model\": model,\n",
-    "    \"labels\": labels,\n",
-    "    \"transform\": transform,\n",
-    "    \"device\": device\n",
-    "}"
+    "model.to(device)"
    ]
   },
   {
@@ -106,7 +98,7 @@
    "source": [
     "## Write batch process function\n",
     "\n",
-    "* Must take list[bytes] and context dict as input\n",
+    "* Must take list[bytes] input\n",
     "* Preprocess all inputs, run inference in batch, postprocess batch model output, return list of formatted results"
    ]
   },
@@ -116,7 +108,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "def batch_process(inputs,context):\n",
+    "def batch_process(inputs):\n",
     "    \n",
     "    # preprocess list of inputs\n",
     "    images = []\n",
@@ -125,10 +117,10 @@
     "        resized = cv2.resize(decoded, (224, 224)).reshape((1,224,224,3))\n",
     "        images.append(resized)\n",
     "    images_arr = np.concatenate(images)\n",
-    "    batch_t = torch.stack(tuple(context['transform'](i) for i in images_arr), dim=0).to(context['device'])\n",
+    "    batch_t = torch.stack(tuple(transform(i) for i in images_arr), dim=0).to(device)\n",
     "\n",
     "    # run batch inference and softmax\n",
-    "    output = context['model'](batch_t)\n",
+    "    output = model(batch_t)\n",
     "    probs = torch.nn.functional.softmax(output, dim=1)\n",
     "    softmax_preds = probs.detach().cpu().numpy()\n",
     "    \n",
@@ -136,7 +128,7 @@
     "    all_formatted_results = []\n",
     "    for preds in softmax_preds: \n",
     "        indices = np.argsort(preds)[::-1]\n",
-    "        classes = [context['labels'][idx] for idx in indices[:5]]\n",
+    "        classes = [labels[idx] for idx in indices[:5]]\n",
     "        scores = [float(preds[idx]) for idx in indices[:5]]\n",
     "        preds = [{\"class\": \"{}\".format(label), \"score\": round(float(score),3)} for label, score in zip(classes, scores)]\n",
     "        preds.sort(key = lambda x: x[\"score\"],reverse=True)\n",
@@ -169,7 +161,6 @@
    "metadata": {},
    "source": [
     "## Create and test Chassis model\n",
-    "* Requires `context` dict containing all variables which should be loaded once and persist across inferences\n",
     "* Requires at least one of single input `process_fn` or batch input `batch_process_fn` defined above\n",
     "    * If you provide `batch_process_fn`, you must also provide a `batch_size`"
    ]
@@ -189,10 +180,10 @@
    ],
    "source": [
     "# create Chassis model\n",
-    "chassis_model = chassis_client.create_model(context=context,batch_process_fn=batch_process,batch_size=4)\n",
+    "chassis_model = chassis_client.create_model(batch_process_fn=batch_process,batch_size=4)\n",
     "\n",
     "# test Chassis model (can pass filepath, bufferedreader, bytes, or text here):\n",
-    "sample_filepath = './modzy/airplane.jpg'\n",
+    "sample_filepath = './data/airplane.jpg'\n",
     "results = chassis_model.test(sample_filepath)\n",
     "print(results)"
    ]

--- a/chassisml-sdk/examples/pytorch/pytorch_tabular_shelter_animal_outcome.ipynb
+++ b/chassisml-sdk/examples/pytorch/pytorch_tabular_shelter_animal_outcome.ipynb
@@ -482,7 +482,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Prepare context dict\n",
+    "## Prepare model\n",
     "Initialize anything here that should persist across inference runs"
    ]
   },
@@ -498,15 +498,7 @@
     "embedded_columns = embedded_col_names\n",
     "output_names = [\"ID\", \"Adoption\", \"Died\", \"Euthanasia\", \"Return_to_owner\", \"Transfer\"]\n",
     "\n",
-    "device = torch.device('cpu')\n",
-    "\n",
-    "# This will be passed to Chassis:\n",
-    "context = {\n",
-    "    \"model\": model_tabular,    \n",
-    "    \"embedded_columns\": embedded_columns,\n",
-    "    \"output_column_names\": output_names,\n",
-    "    \"device\": device\n",
-    "}"
+    "device = torch.device('cpu')"
    ]
   },
   {
@@ -515,7 +507,7 @@
    "source": [
     "## Write process function\n",
     "\n",
-    "* Must take bytes and context dict as input\n",
+    "* Must take bytes as input\n",
     "* Preprocess bytes, run inference, postprocess model output, return results"
    ]
   },
@@ -571,11 +563,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "def process(input_bytes,context):\n",
+    "def process(input_bytes):\n",
     "    \n",
     "    # preprocess\n",
     "    df = pd.read_csv(StringIO(str(input_bytes, \"utf-8\")))\n",
-    "    df = preprocess(df, context[\"embedded_columns\"])\n",
+    "    df = preprocess(df, embedded_columns)\n",
     "    \n",
     "    # run inference\n",
     "    preds = []\n",
@@ -586,7 +578,7 @@
     "    final_probs = [item for sublist in preds for item in sublist] \n",
     "\n",
     "    # postprocess\n",
-    "    output_skeleton = pd.DataFrame(0, index=np.arange(len(final_probs)), columns=context[\"output_column_names\"])\n",
+    "    output_skeleton = pd.DataFrame(0, index=np.arange(len(final_probs)), columns=output_column_names)\n",
     "    output_skeleton[\"ID\"] = [i+1 for i in range(len(final_probs))]\n",
     "    final_output = postprocess(final_probs, output_skeleton)\n",
     "    \n",
@@ -625,7 +617,6 @@
    "metadata": {},
    "source": [
     "## Create and test Chassis model\n",
-    "* Requires `context` dict containing all variables which should be loaded once and persist across inferences\n",
     "* Requires `process_fn` defined above"
    ]
   },
@@ -644,7 +635,7 @@
    ],
    "source": [
     "# create Chassis model\n",
-    "chassis_model = chassis_client.create_model(context=context,process_fn=process)\n",
+    "chassis_model = chassis_client.create_model(process_fn=process)\n",
     "\n",
     "# test Chassis model (can pass filepath, bufferedreader, bytes, or text here):\n",
     "sample_filepath = \"./data/animal-shelter-outcomes/sample_data.csv\"\n",

--- a/chassisml-sdk/examples/sklearn/sklearn_logreg_image_classification.ipynb
+++ b/chassisml-sdk/examples/sklearn/sklearn_logreg_image_classification.ipynb
@@ -109,27 +109,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Prepare context dict\n",
-    "Initialize anything here that should persist across inference runs"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 9,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# This will be passed to Chassis:\n",
-    "context = {\"model\": logistic}"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
     "## Write process function\n",
     "\n",
-    "* Must take bytes and context dict as input\n",
+    "* Must take bytes as input\n",
     "* Preprocess bytes, run inference, postprocess model output, return results"
    ]
   },
@@ -139,9 +121,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "def process(input_bytes,context):\n",
+    "def process(input_bytes):\n",
     "    inputs = np.array(json.loads(input_bytes))\n",
-    "    inference_results = context[\"model\"].predict(inputs)\n",
+    "    inference_results = logistic.predict(inputs)\n",
     "    structured_results = []\n",
     "    for inference_result in inference_results:\n",
     "        structured_output = {\n",
@@ -175,7 +157,6 @@
    "metadata": {},
    "source": [
     "## Create and test Chassis model\n",
-    "* Requires `context` dict containing all variables which should be loaded once and persist across inferences\n",
     "* Requires `process_fn` defined above"
    ]
   },
@@ -196,7 +177,7 @@
    ],
    "source": [
     "# create Chassis model\n",
-    "chassis_model = chassis_client.create_model(context=context,process_fn=process)\n",
+    "chassis_model = chassis_client.create_model(process_fn=process)\n",
     "\n",
     "# test Chassis model locally (can pass filepath, bufferedreader, bytes, or text here):\n",
     "sample_filepath = './data/digits_sample.json'\n",

--- a/chassisml-sdk/examples/sklearn/sklearn_svm_image_classification.ipynb
+++ b/chassisml-sdk/examples/sklearn/sklearn_svm_image_classification.ipynb
@@ -91,27 +91,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Prepare context dict\n",
-    "Initialize anything here that should persist across inference runs"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 4,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# This will be passed to Chassis:\n",
-    "context = {\"model\": clf}"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
     "## Write process function\n",
     "\n",
-    "* Must take bytes and context dict as input\n",
+    "* Must take bytes as input\n",
     "* Preprocess bytes, run inference, postprocess model output, return results"
    ]
   },
@@ -121,9 +103,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "def process(input_bytes,context):\n",
+    "def process(input_bytes):\n",
     "    inputs = np.array(json.loads(input_bytes))/2\n",
-    "    inference_results = context[\"model\"].predict(inputs)\n",
+    "    inference_results = clf.predict(inputs)\n",
     "    structured_results = []\n",
     "    for inference_result in inference_results:\n",
     "        structured_output = {\n",
@@ -157,7 +139,6 @@
    "metadata": {},
    "source": [
     "## Create and test Chassis model\n",
-    "* Requires `context` dict containing all variables which should be loaded once and persist across inferences\n",
     "* Requires `process_fn` defined above"
    ]
   },
@@ -178,7 +159,7 @@
    ],
    "source": [
     "# create Chassis model\n",
-    "chassis_model = chassis_client.create_model(context=context,process_fn=process)\n",
+    "chassis_model = chassis_client.create_model(process_fn=process)\n",
     "\n",
     "# test Chassis model locally (can pass filepath, bufferedreader, bytes, or text here):\n",
     "sample_filepath = './modzy/input_sample.json'\n",

--- a/chassisml-sdk/examples/sklearn/sklearn_tree_wine_classification.ipynb
+++ b/chassisml-sdk/examples/sklearn/sklearn_tree_wine_classification.ipynb
@@ -275,32 +275,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Prepare context dict\n",
-    "Initialize anything here that should persist across inference runs"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 162,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# This will be passed to Chassis:\n",
-    "context = {\n",
-    "    \"model\": model,\n",
-    "    \"classes\": [\"bad\", \"good\"],\n",
-    "    \"feature_labels\": list(X_train.columns),\n",
-    "    \"train_data\": X_train\n",
-    "}"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
     "## Write process function\n",
     "\n",
-    "* Must take bytes and context dict as input\n",
+    "* Must take bytes as input\n",
     "* Preprocess bytes, run inference, postprocess model output, return results"
    ]
   },
@@ -338,21 +315,23 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "def process(input_bytes,context):\n",
+    "classes = [\"bad\", \"good\"]\n",
+    "feature_labels = list(X_train.columns)\n",
+    "def process(input_bytes):\n",
     "    inputs = pd.read_csv(StringIO(str(input_bytes, \"utf-8\")))\n",
-    "    preds = context[\"model\"].predict_proba(inputs)\n",
+    "    preds = model.predict_proba(inputs)\n",
     "    \n",
     "    inference_result = {\n",
     "        \"classPredictions\": [\n",
-    "            {\"row\": i+1, \"class\": context[\"classes\"][np.argmax(pred)], \"score\": np.max(pred)} for i, pred in enumerate(preds)\n",
+    "            {\"row\": i+1, \"class\": classes[np.argmax(pred)], \"score\": np.max(pred)} for i, pred in enumerate(preds)\n",
     "        ]\n",
     "    }\n",
     "    \n",
-    "    exp_list, exp_map = explain(X_test, context[\"train_data\"], context[\"model\"].predict_proba)\n",
+    "    exp_list, exp_map = explain(X_test, X_train, model.predict_proba)\n",
     "    explainable_results = {\n",
     "        \"featureImportance\": [\n",
     "            {\n",
-    "                \"feature\": context[\"feature_labels\"][exp_map[1][i][0]],\n",
+    "                \"feature\": feature_labels[exp_map[1][i][0]],\n",
     "                \"condition\": exp_list[i][0],\n",
     "                \"score\": exp_list[i][1]\n",
     "            } for i in range(len(exp_list))\n",
@@ -392,7 +371,6 @@
    "metadata": {},
    "source": [
     "## Create and test Chassis model\n",
-    "* Requires `context` dict containing all variables which should be loaded once and persist across inferences\n",
     "* Requires `process_fn` defined above"
    ]
   },
@@ -37545,7 +37523,7 @@
    ],
    "source": [
     "# create Chassis model\n",
-    "chassis_model = chassis_client.create_model(context=context,process_fn=process)\n",
+    "chassis_model = chassis_client.create_model(process_fn=process)\n",
     "\n",
     "# test Chassis model locally (can pass filepath, bufferedreader, bytes, or text here):\n",
     "sample_filepath = 'data/wine_sample_set.csv'\n",

--- a/chassisml-sdk/examples/xgboost/xgboost_house_price_predictions.ipynb
+++ b/chassisml-sdk/examples/xgboost/xgboost_house_price_predictions.ipynb
@@ -240,29 +240,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Prepare context dict\n",
-    "Initialize anything here that should persist across inference runs"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 35,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# This will be passed to Chassis:\n",
-    "context = {\n",
-    "    \"model\": regressor,\n",
-    "}"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
     "## Write process function\n",
     "\n",
-    "* Must take bytes and context dict as input\n",
+    "* Must take bytes as input\n",
     "* Preprocess bytes, run inference, postprocess model output, return results"
    ]
   },
@@ -272,12 +252,12 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "def process(input_bytes,context):\n",
+    "def process(input_bytes):\n",
     "    # load data\n",
     "    inputs = pd.read_csv(StringIO(str(input_bytes, \"utf-8\")))    \n",
     "    \n",
     "    # run inference\n",
-    "    preds = context[\"model\"].predict(inputs)\n",
+    "    preds = regressor.predict(inputs)\n",
     "    \n",
     "    # structure results\n",
     "    inference_result = {\n",
@@ -318,7 +298,6 @@
    "metadata": {},
    "source": [
     "## Create and test Chassis model\n",
-    "* Requires `context` dict containing all variables which should be loaded once and persist across inferences\n",
     "* Requires `process_fn` defined above"
    ]
   },
@@ -339,7 +318,7 @@
    ],
    "source": [
     "# create Chassis model\n",
-    "chassis_model = chassis_client.create_model(context=context,process_fn=process)\n",
+    "chassis_model = chassis_client.create_model(process_fn=process)\n",
     "\n",
     "# test Chassis model locally (can pass filepath, bufferedreader, bytes, or text here):\n",
     "sample_filepath = './data/sample_house_data.csv'\n",

--- a/chassisml-sdk/setup.py
+++ b/chassisml-sdk/setup.py
@@ -10,7 +10,7 @@ with open('README.md', 'r') as fh:
 
 setup(
     name='chassisml',
-    version='1.2.2',
+    version='1.3.0',
     author='Carlos Millán Soler',
     author_email='cmillan@sciling.com',
     description='Python API client for Chassis.',


### PR DESCRIPTION
Updated Chassis SDK:
Removed context dict, those variables are now accessed directly in process function.

PR Overview:
Chassis previously required the user-provided process function to take a context dictionary as one of its arguments. The way that MLFlow saves out models makes this unnecessary.

PR Known Issues:
None