### PR TITLE
Feat/versioning

### DIFF
--- a/chassisml-sdk/chassisml/__init__.py
+++ b/chassisml-sdk/chassisml/__init__.py
@@ -4,6 +4,6 @@
 """Chassis Python API Client."""
 
 name = 'chassisml'
-__version__ = '1.3.0'
+__version__ = '1.3.1'
 
 from .chassisml import ChassisClient,ChassisModel

--- a/chassisml-sdk/chassisml/chassisml.py
+++ b/chassisml-sdk/chassisml/chassisml.py
@@ -233,7 +233,7 @@ class ChassisModel(mlflow.pyfunc.PythonModel):
     def publish(self,model_name,model_version,registry_user,registry_pass,
                 conda_env=None,fix_env=True,gpu=False,arm64=False,
                 modzy_sample_input_path=None,modzy_api_key=None,
-                modzy_url=None):
+                modzy_url=None,modzy_model_id=None):
         '''
         Executes chassis job, which containerizes model, pushes container image to Docker registry, and optionally deploys model to Modzy
 
@@ -249,6 +249,7 @@ class ChassisModel(mlflow.pyfunc.PythonModel):
             modzy_sample_input_path (str): Filepath to sample input data. Required to deploy model to Modzy
             modzy_api_key (str): Valid Modzy API Key
             modzy_url (str): Valid Modzy instance URL, example: https://my.modzy.com
+            modzy_model_id (str): Existing Modzy model identifier, if requesting new version of existing model instead of new model
 
         Returns:
             Dict: Response to Chassis `/build` endpoint
@@ -311,7 +312,8 @@ class ChassisModel(mlflow.pyfunc.PythonModel):
                     'sample_input_path': modzy_sample_input_path,
                     'deploy': True,
                     'api_key': modzy_api_key,
-                    'modzy_url': modzy_url
+                    'modzy_url': modzy_url,
+                    'modzy_model_id': modzy_model_id
                 }
                 write_modzy_yaml(model_name,model_version,modzy_metadata_path,batch_size=self.batch_size,gpu=gpu)
             else:

--- a/chassisml-sdk/setup.py
+++ b/chassisml-sdk/setup.py
@@ -10,7 +10,7 @@ with open('README.md', 'r') as fh:
 
 setup(
     name='chassisml',
-    version='1.3.0',
+    version='1.3.1',
     author='Carlos Millán Soler',
     author_email='cmillan@sciling.com',
     description='Python API client for Chassis.',

--- a/modzy-uploader/app.py
+++ b/modzy-uploader/app.py
@@ -28,6 +28,7 @@ parser.add_argument('--sample_input_path', type=str, required=False)
 parser.add_argument('--metadata_path', type=str, required=False)
 parser.add_argument('--modzy_uri', type=str, required=False)
 parser.add_argument('--modzy_url', type=str, required=False)
+parser.add_argument('--model_id', type=str, required=False)
 args = parser.parse_args()
 
 JOB_NAME = os.getenv('JOB_NAME')
@@ -52,6 +53,7 @@ routes = {
     'run_model': '/api/models/{}/versions/{}/run-process',
     'deploy_model': '/api/models/{}/versions/{}',
     'model_url': '/models/{}/{}',
+    'create_version': '/api/models/{}/versions'
 }
 
 def download_modzy_data(modzy_uri):
@@ -109,7 +111,9 @@ def create_model(metadata):
 
     logger.info(f'create_model returned took [{1000*(time.time()-start)} ms]')
 
-    return res.json()
+    model_data = res.json()
+
+    return model_data.get('identifier'), version
 
 def add_tags_and_description(identifier, metadata):
 
@@ -304,9 +308,10 @@ def upload_model(modzy_dir=None):
     with open(yaml_path, 'r') as f:
         metadata = yaml.safe_load(f)
 
-    model_data = create_model(metadata)
-
-    identifier, version = model_data.get('identifier'), metadata.get('version')
+    if args.model_id:
+        identifier, version = args.model_id,metadata.get('version')
+    else:
+        identifier, version = create_model(metadata)
 
     logger.debug(f'Identifier: {identifier}, Version: {version}')
 

--- a/service/target_utils/modzy_utils.py
+++ b/service/target_utils/modzy_utils.py
@@ -1,0 +1,10 @@
+import requests
+
+def create_version(modzy_client,modzy_model_id,requested_version):
+    model = modzy_client.models.get(modzy_model_id)
+    if requested_version in model.versions:
+        raise ValueError("Requested model version already exists.")
+    create_version_url = modzy_client.base_url + f'models/{modzy_model_id}/versions'
+    data = {"version": requested_version}
+    res = requests.post(create_version_url, json=data, headers={'Authorization': f'ApiKey {modzy_client.api_key}'})
+    res.raise_for_status()

--- a/service/target_utils/modzy_utils.py
+++ b/service/target_utils/modzy_utils.py
@@ -7,4 +7,5 @@ def create_version(modzy_client,modzy_model_id,requested_version):
     create_version_url = modzy_client.base_url + f'models/{modzy_model_id}/versions'
     data = {"version": requested_version}
     res = requests.post(create_version_url, json=data, headers={'Authorization': f'ApiKey {modzy_client.api_key}'})
-    res.raise_for_status()
+    if not res.ok and not "already exists" in res.text:
+        res.raise_for_status()


### PR DESCRIPTION
Updated Chassis SDK, Chassis Service, and Modzy Uploader:
Allow user to specify existing Modzy model identifier and add new version.

PR Overview:
User can optionally specify existing Modzy model identifier in their call to publish method in SDK, service will make sure that the model exists in the Modzy instance and that the new requested version can be created before performing the build job.

PR Known Issues:
Model name provided in publish method will not be used for new Modzy model version if existing model id provided. I believe this is the correct behavior, let me know if you disagree.