### PR TITLE
fix: added grpcio dependency to install latest version

### DIFF
--- a/chassisml-sdk/chassisml/__init__.py
+++ b/chassisml-sdk/chassisml/__init__.py
@@ -4,6 +4,6 @@
 """Chassis Python API Client."""
 
 name = 'chassisml'
-__version__ = '1.3.2'
+__version__ = '1.3.3'
 
 from .chassisml import ChassisClient,ChassisModel

--- a/chassisml-sdk/setup.py
+++ b/chassisml-sdk/setup.py
@@ -10,7 +10,7 @@ with open('README.md', 'r') as fh:
 
 setup(
     name='chassisml',
-    version='1.3.2',
+    version='1.3.3',
     author='Carlos Millán Soler',
     author_email='cmillan@sciling.com',
     description='Python API client for Chassis.',

--- a/chassisml-sdk/setup.py
+++ b/chassisml-sdk/setup.py
@@ -18,7 +18,7 @@ setup(
     long_description_content_type='text/markdown',
     packages=find_packages(),
     python_requires='>=3.6',
-    install_requires=['requests','mlflow','numpy','pyyaml','validators','grpc-requests','docker'],
+    install_requires=['requests','mlflow','numpy','pyyaml','validators','grpc-requests','grpcio>=1.44.0','docker'],
     url='https://github.com/modzy/chassis/tree/main/chassisml-sdk',
     zip_safe=False,
 )


### PR DESCRIPTION
This PR adds the `grpcio` package into the SDK `setup.py` configuration. Currently, it just includes `grpc-requests` which installs an older version of `grpcio`, which has resulted in periodic dependency version issues.