### PR TITLE
add custom pip and conda repo hooks

### DIFF
--- a/chassisml_sdk/examples/requirements.txt
+++ b/chassisml_sdk/examples/requirements.txt
@@ -1,5 +1,5 @@
 modzy-sdk>=0.6.0
-chassisml==1.1.2
+chassisml>=1.3
 cloudpickle==2.0.0
 ipykernel==6.6.0
 mlflow>=1.23.1

--- a/service/.env
+++ b/service/.env
@@ -1,5 +1,9 @@
 # APP
 PORT=5000
+#Testing repos
+#PYPI_REPO=http://local.repo/repodir
+#CONDA_CHANNEL_ALIAS=http://successfully.failed
+
 # mount path inside of Kaniko container
 # this path works on Windows and POSIX. Windows will interpret root to mean "C" drive so /data will internally map to C:/data
 MOUNT_PATH_DIR=/data

--- a/service/app.py
+++ b/service/app.py
@@ -35,7 +35,7 @@ from libcloud.storage.providers import get_driver
 
 load_dotenv()
 
-CHASSIS_DEV = False
+CHASSIS_DEV = True
 WINDOWS = True if os.name == 'nt' else False
 
 HOME_DIR = str(Path.home())
@@ -364,6 +364,9 @@ def create_job_object(
         f'--build-arg=MODEL_CLASS={module_name}',
         # Modzy is the default interface.
         '--build-arg=INTERFACE=modzy',
+        f'--build-arg=PYPI_REPO={os.getenv("PYPI_REPO") if os.getenv("PYPI_REPO") is not None else "https://pypi.org/simple"}',
+        f'--build-arg=CONDA_THANNEL_ALIAS={os.getenv("CONDA_CHANNEL_ALIAS") if os.getenv("CONDA_CHANNEL_ALIAS") is not None else "channel_alias: https://conda.anaconda.org/"}',
+
     ]
 
     modzy_uploader_args = [

--- a/service/app.py
+++ b/service/app.py
@@ -35,7 +35,7 @@ from libcloud.storage.providers import get_driver
 
 load_dotenv()
 
-CHASSIS_DEV = True
+CHASSIS_DEV = False
 WINDOWS = True if os.name == 'nt' else False
 
 HOME_DIR = str(Path.home())

--- a/service/app.py
+++ b/service/app.py
@@ -364,8 +364,8 @@ def create_job_object(
         f'--build-arg=MODEL_CLASS={module_name}',
         # Modzy is the default interface.
         '--build-arg=INTERFACE=modzy',
-        f'--build-arg=PYPI_REPO={os.getenv("PYPI_REPO") if os.getenv("PYPI_REPO") is not None else "https://pypi.org/simple"}',
-        f'--build-arg=CONDA_THANNEL_ALIAS={os.getenv("CONDA_CHANNEL_ALIAS") if os.getenv("CONDA_CHANNEL_ALIAS") is not None else "channel_alias: https://conda.anaconda.org/"}',
+        f'--build-arg=CHASSIS_PYPI_REPO={os.getenv("PYPI_REPO") if os.getenv("PYPI_REPO") is not None else "https://pypi.org/simple"}',
+        f'--build-arg=CHASSIS_CONDA_CHANNEL_ALIAS={os.getenv("CONDA_CHANNEL_ALIAS") if os.getenv("CONDA_CHANNEL_ALIAS") is not None else "channel_alias: https://conda.anaconda.org/"}',
 
     ]
 

--- a/service/flavours/mlflow/Dockerfile
+++ b/service/flavours/mlflow/Dockerfile
@@ -11,9 +11,9 @@ ARG INTERFACE
 # This is the model.yaml file.
 ARG MODZY_METADATA_PATH
 #PyPi Repo
-ARG PYPI_REPO
+ARG CHASSIS_PYPI_REPO
 #Conda Repo
-ARG CONDA_THANNEL_ALIAS
+ARG CHASSIS_CONDA_CHANNEL_ALIAS
 
 #OMI Annotations
 LABEL ml.openmodel.interfaces=["${INTERFACE}"]
@@ -29,13 +29,13 @@ RUN apt-get update && apt-get install -y build-essential cmake
 #set Python repos
 RUN mkdir ~/.pip
 RUN echo '[global]' >| ~/.pip/pip.conf
-RUN echo 'index-url = '${PYPI_REPO} >> ~/.pip/pip.conf
+RUN echo 'index-url = '${CHASSIS_PYPI_REPO} >> ~/.pip/pip.conf
 
 RUN echo 'channels:'>| ~/.condarc
 RUN echo '  - r'>> ~/.condarc
 RUN echo '  - defaults'>> ~/.condarc
 RUN echo 'show_channel_urls: True'>> ~/.condarc
-RUN echo ${CONDA_THANNEL_ALIAS} >> ~/.condarc
+RUN echo ${CHASSIS_CONDA_CHANNEL_ALIAS} >> ~/.condarc
 
 # create env
 ENV CONDA_ENV chassis-env

--- a/service/flavours/mlflow/Dockerfile
+++ b/service/flavours/mlflow/Dockerfile
@@ -10,9 +10,12 @@ ARG MODEL_CLASS
 ARG INTERFACE
 # This is the model.yaml file.
 ARG MODZY_METADATA_PATH
+#PyPi Repo
+ARG PYPI_REPO
+#Conda Repo
+ARG CONDA_THANNEL_ALIAS
 
 #OMI Annotations
-
 LABEL ml.openmodel.interfaces=["${INTERFACE}"]
 LABEL ml.openml.model_name="${MODEL_NAME}"
 LABEL ml.openmodel.protocols=[["v2"]]
@@ -22,6 +25,18 @@ LABEL ml.openmodel.port="45000"
 WORKDIR /app
 
 RUN apt-get update && apt-get install -y build-essential cmake
+
+#set Python repos
+RUN mkdir ~/.pip
+RUN echo '[global]' >| ~/.pip/pip.conf
+RUN echo 'index-url = '${PYPI_REPO} >> ~/.pip/pip.conf
+
+RUN echo 'channels:'>| ~/.condarc
+RUN echo '  - r'>> ~/.condarc
+RUN echo '  - defaults'>> ~/.condarc
+RUN echo 'show_channel_urls: True'>> ~/.condarc
+RUN echo ${CONDA_THANNEL_ALIAS} >> ~/.condarc
+
 # create env
 ENV CONDA_ENV chassis-env
 

--- a/service/flavours/mlflow/Dockerfile.arm
+++ b/service/flavours/mlflow/Dockerfile.arm
@@ -2,8 +2,7 @@
 # - flavours
 #   - mlflow
 
-FROM balenalib/aarch64-ubuntu-python:3-latest-build
-
+FROM balenalib/aarch64-ubuntu-python:3-latest-build-20220513
 RUN [ "cross-build-start" ]
 
 # Install miniconda

--- a/service/flavours/mlflow/Dockerfile.arm
+++ b/service/flavours/mlflow/Dockerfile.arm
@@ -21,8 +21,24 @@ ARG MODEL_CLASS
 ARG INTERFACE
 # This is the model.yaml file.
 ARG MODZY_METADATA_PATH
+#PyPi Repo
+ARG CHASSIS_PYPI_REPO
+#Conda Repo
+ARG CHASSIS_CONDA_CHANNEL_ALIAS
 
 WORKDIR /app
+
+#set Python repos
+RUN mkdir ~/.pip
+RUN echo '[global]' >| ~/.pip/pip.conf
+RUN echo 'index-url = '${CHASSIS_PYPI_REPO} >> ~/.pip/pip.conf
+
+RUN echo 'channels:'>| ~/.condarc
+RUN echo '  - r'>> ~/.condarc
+RUN echo '  - defaults'>> ~/.condarc
+RUN echo 'show_channel_urls: True'>> ~/.condarc
+RUN echo ${CHASSIS_CONDA_CHANNEL_ALIAS} >> ~/.condarc
+
 
 COPY flavours/${MODEL_CLASS}/${MODEL_DIR}/conda.yaml ./conda.yaml
 

--- a/service/flavours/mlflow/Dockerfile.arm.gpu
+++ b/service/flavours/mlflow/Dockerfile.arm.gpu
@@ -18,8 +18,23 @@ ARG MODEL_CLASS
 ARG INTERFACE
 # This is the model.yaml file.
 ARG MODZY_METADATA_PATH
+#PyPi Repo
+ARG CHASSIS_PYPI_REPO
+#Conda Repo
+ARG CHASSIS_CONDA_CHANNEL_ALIAS
 
 WORKDIR /app
+
+#set Python repos
+RUN mkdir ~/.pip
+RUN echo '[global]' >| ~/.pip/pip.conf
+RUN echo 'index-url = '${CHASSIS_PYPI_REPO} >> ~/.pip/pip.conf
+
+RUN echo 'channels:'>| ~/.condarc
+RUN echo '  - r'>> ~/.condarc
+RUN echo '  - defaults'>> ~/.condarc
+RUN echo 'show_channel_urls: True'>> ~/.condarc
+RUN echo ${CHASSIS_CONDA_CHANNEL_ALIAS} >> ~/.condarc
 
 COPY flavours/${MODEL_CLASS}/${MODEL_DIR}/requirements.txt ./user_requirements.txt
 

--- a/service/flavours/mlflow/Dockerfile.gpu
+++ b/service/flavours/mlflow/Dockerfile.gpu
@@ -20,8 +20,23 @@ ARG MODEL_CLASS
 ARG INTERFACE
 # This is the model.yaml file.
 ARG MODZY_METADATA_PATH
+#PyPi Repo
+ARG CHASSIS_PYPI_REPO
+#Conda Repo
+ARG CHASSIS_CONDA_CHANNEL_ALIAS
 
 WORKDIR /app
+
+#set Python repos
+RUN mkdir ~/.pip
+RUN echo '[global]' >| ~/.pip/pip.conf
+RUN echo 'index-url = '${CHASSIS_PYPI_REPO} >> ~/.pip/pip.conf
+
+RUN echo 'channels:'>| ~/.condarc
+RUN echo '  - r'>> ~/.condarc
+RUN echo '  - defaults'>> ~/.condarc
+RUN echo 'show_channel_urls: True'>> ~/.condarc
+RUN echo ${CHASSIS_CONDA_CHANNEL_ALIAS} >> ~/.condarc
 
 COPY flavours/${MODEL_CLASS}/${MODEL_DIR}/conda.yaml ./conda.yaml
 


### PR DESCRIPTION
PR updates the kaniko build arguments and all four Dockerfiles to allow the user to specify repos for both pip and conda through environment variables.