### PR TITLE
set protobuf version, add ssl verification args

### DIFF
--- a/chassisml_sdk/chassisml/__init__.py
+++ b/chassisml_sdk/chassisml/__init__.py
@@ -4,6 +4,6 @@
 """Chassis Python API Client."""
 
 name = 'chassisml'
-__version__ = '1.4.2'
+__version__ = '1.4.3'
 
 from .chassisml import ChassisClient,ChassisModel

--- a/chassisml_sdk/setup.py
+++ b/chassisml_sdk/setup.py
@@ -10,7 +10,7 @@ with open('README.md', 'r') as fh:
 
 setup(
     name='chassisml',
-    version='1.4.2',
+    version='1.4.3',
     author='Carlos Millán Soler',
     author_email='cmillan@sciling.com',
     description='Python API client for Chassis.',
@@ -18,7 +18,7 @@ setup(
     long_description_content_type='text/markdown',
     packages=find_packages(),
     python_requires='>=3.6',
-    install_requires=['requests','mlflow','numpy','pyyaml','validators','grpc-requests','grpcio>=1.44.0','docker'],
+    install_requires=['requests','mlflow','numpy','pyyaml','validators','grpc-requests','grpcio>=1.44.0','docker','protobuf==3.19.4'],
     url='https://github.com/modzy/chassis/tree/main/chassisml_sdk',
     zip_safe=False,
 )


### PR DESCRIPTION
Fixed protobuf version, added ability to specify cert or override verification in all requests made to service by setting an additional `ssl_verification` argument when initializing `ChassisClient`