### PR TITLE
Use user's Python version as default.

### DIFF
--- a/packages/chassisml/src/chassis/builder/options.py
+++ b/packages/chassisml/src/chassis/builder/options.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import sys
 import dataclasses
 import platform
 from typing import List, Optional, Union
@@ -55,7 +56,7 @@ class BuildOptions:
     """
     base_dir: Optional[str] = None
     arch: Union[str, List[str]] = platform.machine() or "amd64"
-    python_version: str = "3.9"
+    python_version: str = f"{sys.version_info.major}.{sys.version_info.minor}"
     cuda_version: Optional[str] = None
     server: str = "omi"
 

--- a/packages/chassisml/tests/test_render_dockerfile.py
+++ b/packages/chassisml/tests/test_render_dockerfile.py
@@ -1,3 +1,4 @@
+import sys
 import re
 
 import pytest
@@ -10,7 +11,7 @@ def test_render_cpu_dockerfile(echo_predict_function):
     model = ChassisModel(echo_predict_function)
     options = BuildOptions()
     rendered_dockerfile = model.render_dockerfile(options)
-    assert rendered_dockerfile.startswith("FROM python:3.9-slim-bullseye")
+    assert rendered_dockerfile.startswith(f"FROM python:{sys.version_info.major}.{sys.version_info.minor}-slim-bullseye")
 
 
 def test_render_gpu_dockerfile(echo_predict_function):
@@ -22,9 +23,9 @@ def test_render_gpu_dockerfile(echo_predict_function):
 
 def test_render_cpu_dockerfile_with_nondefault_python_version(echo_predict_function):
     model = ChassisModel(echo_predict_function)
-    options = BuildOptions(python_version="3.10")
+    options = BuildOptions(python_version="4.0")
     rendered_dockerfile = model.render_dockerfile(options)
-    assert rendered_dockerfile.startswith("FROM python:3.10-slim-bullseye")
+    assert rendered_dockerfile.startswith("FROM python:4.0-slim-bullseye")
 
 
 def test_render_dockerfile_with_no_apt_packages(echo_predict_function):


### PR DESCRIPTION
Rather than hard-coding Python 3.9 as the default version, detect which version of Python the user is currently using and use the Major.Minor (ignoring Patch) version as the default Python version if one is not specified as a part of the `BuildOptions`.